### PR TITLE
set default runtime for python from environment

### DIFF
--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -32,7 +33,7 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     runtime: str
     source_code: DirectoryPath
 
-    @validator("source_code")
+    @validator("source_code", allow_reuse=True)
     def _resolve_path(cls, v: Path) -> Path:
         return v.resolve()
 
@@ -40,7 +41,7 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
 class PythonFunctionHookArgs(AwsLambdaHookArgs):
     """Hook arguments for a Python function.
 
-    Args:
+    Attributes:
         extend_pip_args: Additional arguments that should be passed to pip.
         use_pipenv: Whether pipenv should be used if determined appropriate.
         use_poetry: Whether poetry should be used if determined appropriate.
@@ -48,6 +49,7 @@ class PythonFunctionHookArgs(AwsLambdaHookArgs):
     """
 
     extend_pip_args: Optional[List[str]] = None
+    runtime: str = f"python{sys.version_info.major}.{sys.version_info.minor}"
     use_pipenv: bool = True
     use_poetry: bool = True
 

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -2,17 +2,13 @@
 # pylint: disable=no-self-use,protected-access
 from __future__ import annotations
 
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
-from mock import Mock
 from pydantic import ValidationError
 
 from awslambda.models.args import AwsLambdaHookArgs, PythonFunctionHookArgs
-
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
 
 MODULE = "awslambda.models.args"
 
@@ -87,7 +83,6 @@ class TestPythonFunctionHookArgs:
                 bucket_name="test-bucket",
                 function_name="name",
                 invalid=True,
-                runtime="test",
                 source_code=tmp_path,
             )
         errors = excinfo.value.errors()
@@ -100,21 +95,9 @@ class TestPythonFunctionHookArgs:
         obj = PythonFunctionHookArgs(  # these are all required fields
             bucket_name="test-bucket",
             function_name="name",
-            runtime="test",
             source_code=tmp_path,
         )
         assert not obj.extend_pip_args
+        assert obj.runtime == f"python{sys.version_info.major}.{sys.version_info.minor}"
         assert obj.use_pipenv
         assert obj.use_poetry
-
-    def test_runtime_from_sys(self, mocker: MockerFixture) -> None:
-        """Test infer runtime from environment."""
-        major = 3
-        minor = 9
-        mocker.patch(f"{MODULE}.sys", version_info=Mock(major=major, minor=minor))
-        assert (
-            PythonFunctionHookArgs(
-                bucket_name="test-bucket", function_name="name", source_code="./"
-            ).runtime
-            == f"python{major}.{minor}"
-        )


### PR DESCRIPTION
# Summary

Infer python runtime from the environment if it is not provided.

# What Changed

## Changed

- `awslambda.models.args.PythonFunctionHookArgs.runtime` now has a dynamic default value based on the execution environment
