### PR TITLE
add runtime to hook response & deployment package tags

### DIFF
--- a/awslambda/base_classes.py
+++ b/awslambda/base_classes.py
@@ -201,6 +201,11 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
         return result
 
     @cached_property
+    def runtime(self) -> str:
+        """Runtime of the deployment package."""
+        return self.args.runtime
+
+    @cached_property
     def source_code(self) -> SourceCode:
         """Project source code.
 
@@ -297,6 +302,7 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
             code_sha256=self.deployment_package.code_sha256,
             object_key=self.deployment_package.object_key,
             object_version_id=self.deployment_package.object_version_id,
+            runtime=self.deployment_package.runtime,
         )
 
     def _build_response_destroy(self) -> Optional[BaseModel]:

--- a/awslambda/models/responses.py
+++ b/awslambda/models/responses.py
@@ -16,6 +16,7 @@ class AwsLambdaHookDeployResponse(BaseModel):
         object_key: Key (file path) of the deployment package S3 Object.
         object_version_id: The version ID of the deployment package S3 Object.
             This will only have a value if the S3 Bucket has versioning enabled.
+        runtime: Runtime of the Lambda Function.
 
     """
 
@@ -23,6 +24,7 @@ class AwsLambdaHookDeployResponse(BaseModel):
     code_sha256: str = Field(..., alias="CodeSha256")
     object_key: str = Field(..., alias="S3Key")
     object_version_id: Optional[str] = Field(None, alias="S3ObjectVersion")
+    runtime: str = Field(..., alias="Runtime")
 
     class Config:
         """Model configuration."""

--- a/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
@@ -19,6 +19,7 @@ class TestAwsLambdaHookDeployResponse:
                 code_sha256="sha256",
                 invalid=True,
                 object_key="key",
+                runtime="test",
             )
         errors = excinfo.value.errors()
         assert len(errors) == 1

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -47,6 +47,7 @@ class TestAwsLambdaHook:
                 code_sha256="sha256",
                 object_key="key",
                 object_version_id="version",
+                runtime="runtime",
             ),
         )
         deployment_package.bucket.name = "test-bucket"
@@ -55,6 +56,7 @@ class TestAwsLambdaHook:
             "code_sha256": deployment_package.code_sha256,
             "object_key": deployment_package.object_key,
             "object_version_id": deployment_package.object_version_id,
+            "runtime": deployment_package.runtime,
         }
 
     def test_build_response_destroy(self, cfngin_context: CfnginContext) -> None:
@@ -294,6 +296,11 @@ class TestProject:
         """Test install_dependencies."""
         with pytest.raises(NotImplementedError):
             assert Project(Mock(), cfngin_context).install_dependencies()
+
+    def test_runtime(self) -> None:
+        """Test runtime."""
+        args = Mock(runtime="runtime")
+        assert Project(args, Mock()).runtime == args.runtime
 
     def test_source_code(
         self, cfngin_context: CfnginContext, mocker: MockerFixture


### PR DESCRIPTION
# Summary

The expected runtime of the deployment package is now included in the response returned by the hook and the metadata tags applied to the deployment package object in S3.

# What Changed

## Added

- added `runtime` attribute to `awslambda.models.response.AwsLambdaHookDeployResponse` (field alias of `Runtime` to match CloudFormation property)
- added `runtime` cached property to `awslambda.base_classes.Project` with the intent to add logic at the project level to determine the desired/required runtime when building a deployment package
- added `runtime` cached property to `awslambda.deployment_package.DeploymentPackage` with the intent to add logic to set the value as the _actual_ runtime of the deployment package
	- for the time being, the value is tied directly to the value of the project's desired/required runtime
- added `runway.cfngin:awslambda.runtime` metadata tag to deployment package s3 object
	- this is now a required tag meaning it is a breaking change for all objects uploaded without it
- added `runtime` cached property to `awslambda.deployment_package.DeploymentPackageS3Object` that reads the value from the metadata tag
