### PR TITLE
replace hashing logic with use of runway.utils.FileHash

### DIFF
--- a/tests/unit/cfngin/hooks/awslambda/test_deployment_package.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_deployment_package.py
@@ -235,12 +235,22 @@ class TestDeploymentPackage:
         self, mocker: MockerFixture, project: ProjectTypeAlias
     ) -> None:
         """Test code_sha256."""
-        mock_calculate_lambda_code_sha256 = mocker.patch(
-            f"{MODULE}.calculate_lambda_code_sha256", return_value="sha256"
+        archive_file = mocker.patch.object(
+            DeploymentPackage, "archive_file", "archive_file"
         )
-        obj = DeploymentPackage(project)
-        assert obj.code_sha256 == mock_calculate_lambda_code_sha256.return_value
-        mock_calculate_lambda_code_sha256.assert_called_once_with(obj.archive_file)
+        file_hash = Mock(digest="digest")
+        mock_b64encode = mocker.patch("base64.b64encode", return_value=b"success")
+        mock_file_hash_class = mocker.patch(
+            f"{MODULE}.FileHash", return_value=file_hash
+        )
+        mock_sha256 = mocker.patch("hashlib.sha256")
+        assert (
+            DeploymentPackage(project).code_sha256
+            == mock_b64encode.return_value.decode()
+        )
+        mock_file_hash_class.assert_called_once_with(mock_sha256.return_value)
+        file_hash.add_file.assert_called_once_with(archive_file)
+        mock_b64encode.assert_called_once_with(file_hash.digest)
 
     @pytest.mark.parametrize("should_exist", [False, True])
     def test_exists(self, project: ProjectTypeAlias, should_exist: bool) -> None:
@@ -292,12 +302,22 @@ class TestDeploymentPackage:
         self, mocker: MockerFixture, project: ProjectTypeAlias
     ) -> None:
         """Test md5_checksum."""
-        mock_calculate_s3_content_md5 = mocker.patch(
-            f"{MODULE}.calculate_s3_content_md5", return_value="md5"
+        archive_file = mocker.patch.object(
+            DeploymentPackage, "archive_file", "archive_file"
         )
-        obj = DeploymentPackage(project)
-        assert obj.md5_checksum == mock_calculate_s3_content_md5.return_value
-        mock_calculate_s3_content_md5.assert_called_once_with(obj.archive_file)
+        file_hash = Mock(digest="digest")
+        mock_b64encode = mocker.patch("base64.b64encode", return_value=b"success")
+        mock_file_hash_class = mocker.patch(
+            f"{MODULE}.FileHash", return_value=file_hash
+        )
+        mock_md5 = mocker.patch("hashlib.md5")
+        assert (
+            DeploymentPackage(project).md5_checksum
+            == mock_b64encode.return_value.decode()
+        )
+        mock_file_hash_class.assert_called_once_with(mock_md5.return_value)
+        file_hash.add_file.assert_called_once_with(archive_file)
+        mock_b64encode.assert_called_once_with(file_hash.digest)
 
     @pytest.mark.parametrize("object_prefix", [None, "bar", "/bar/", "/bar/foo/"])
     def test_object_key(

--- a/tests/unit/cfngin/hooks/awslambda/test_source_code.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_source_code.py
@@ -2,13 +2,11 @@
 # pylint: disable=no-self-use,protected-access,redefined-outer-name
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from mock import Mock, call
-from runway.utils import FileHash
 
 from awslambda.source_code import SourceCode
 
@@ -122,16 +120,16 @@ class TestSourceCode:
 
     def test_md5_hash(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test md5_hash."""
-        file0 = tmp_path / "test.txt"
-        file0.write_text("foobar")
-        expected = FileHash(hashlib.md5())
-        expected.add_files([file0], relative_to=tmp_path)
-        mock_sorted = mocker.patch.object(SourceCode, "sorted", return_value=[file0])
-
-        assert (
-            SourceCode(tmp_path, gitignore_filter=Mock()).md5_hash == expected.hexdigest
+        file_hash = Mock(hexdigest="success")
+        mock_file_hash_class = mocker.patch(
+            f"{MODULE}.FileHash", return_value=file_hash
         )
-        mock_sorted.assert_called_once_with()
+        mock_md5 = mocker.patch("hashlib.md5")
+        assert (
+            SourceCode(tmp_path, gitignore_filter=Mock()).md5_hash
+            == file_hash.hexdigest
+        )
+        mock_file_hash_class.assert_called_once_with(mock_md5.return_value)
 
     @pytest.mark.parametrize("reverse", [False, True])
     def test_sorted(self, mocker: MockerFixture, reverse: bool, tmp_path: Path) -> None:


### PR DESCRIPTION
# What Changed

## Changed

- replaced hashing logic with use of runway.utils.FileHash

## Removed

- removed `awslambda.deployment_package.calculate_lambda_code_sha256`
- removed `awslambda.deployment_package.calculate_s3_content_md5`
