### PR TITLE
add support for pipenv

### DIFF
--- a/awslambda/base_classes.py
+++ b/awslambda/base_classes.py
@@ -257,7 +257,7 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
         This is required to set the value of the args attribute.
 
         Args:
-            context: CFNgin context object.
+            context: CFNgin context object (passed in by CFNgin).
 
         """
         self.ctx = context

--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -56,4 +56,4 @@ class PythonFunctionHookArgs(AwsLambdaHookArgs):
     class Config:
         """Model configuration."""
 
-        extra = Extra.forbid
+        extra = Extra.ignore

--- a/awslambda/python_requirements/dependency_managers/__init__.py
+++ b/awslambda/python_requirements/dependency_managers/__init__.py
@@ -1,5 +1,11 @@
 """Python dependency managers."""
 from ._pip import Pip, is_pip_project
+from ._pipenv import (
+    Pipenv,
+    PipenvExportFailedError,
+    PipenvNotFoundError,
+    is_pipenv_project,
+)
 from ._poetry import (
     Poetry,
     PoetryExportFailedError,
@@ -9,9 +15,13 @@ from ._poetry import (
 
 __all__ = [
     "Pip",
+    "Pipenv",
+    "PipenvExportFailedError",
+    "PipenvNotFoundError",
     "Poetry",
     "PoetryExportFailedError",
     "PoetryNotFoundError",
     "is_pip_project",
+    "is_pipenv_project",
     "is_poetry_project",
 ]

--- a/awslambda/python_requirements/dependency_managers/_pipenv.py
+++ b/awslambda/python_requirements/dependency_managers/_pipenv.py
@@ -1,0 +1,98 @@
+"""Pipenv interface."""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Union
+
+from runway.cfngin.exceptions import CfnginError
+from runway.compat import cached_property
+from typing_extensions import Literal
+
+from ...base_classes import DependencyManager
+
+if TYPE_CHECKING:
+    from _typeshed import StrPath
+
+    from ...source_code import SourceCode
+
+LOGGER = logging.getLogger(f"runway.{__name__}")
+
+
+class PipenvExportFailedError(CfnginError):
+    """Pipenv export failed to produce a ``requirements.txt`` file."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Instantiate class. All args/kwargs are passed to parent method."""
+        self.message = (
+            "pipenv lock to requirements.txt format failed; review pipenv's"
+            " output above to troubleshoot"
+        )
+        super().__init__(*args, **kwargs)
+
+
+class PipenvNotFoundError(CfnginError):
+    """Pipenv not installed or found in $PATH."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Instantiate class. All args/kwargs are passed to parent method."""
+        self.message = (
+            "pipenv not installed or not in PATH! "
+            "Install it according to pipenv docs (https://pipenv.pypa.io/en/latest/) "
+            "and ensure it is available in PATH."
+        )
+        super().__init__(*args, **kwargs)
+
+
+class Pipenv(DependencyManager):
+    """Pipenv dependency manager."""
+
+    EXECUTABLE: Final[Literal["pipenv"]] = "pipenv"
+
+    @cached_property
+    def version(self) -> str:
+        """Get pipenv version."""
+        return self._run_command([self.EXECUTABLE, "--version"])
+
+    def export(self, *, dev: bool = False, output: StrPath) -> Path:
+        """Export the lock file to other formats (requirements.txt only).
+
+        The underlying command being executed by this method is
+        ``pipenv lock --requirements``.
+
+        Args:
+            dev: Include development dependencies.
+            output: Path to the output file.
+
+        """
+        output = Path(output)
+        try:
+            result = self._run_command(
+                self.generate_command(
+                    "lock",
+                    dev=dev,
+                    requirements=True,
+                ),
+                suppress_output=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise PipenvExportFailedError from exc
+        output.parent.mkdir(exist_ok=True, parents=True)  # ensure directory exists
+        output.write_text(result)
+        return output
+
+
+def is_pipenv_project(source_code: Union[Path, SourceCode]) -> bool:
+    """Determine if source code is a pipenv project.
+
+    Args:
+        source_code: Source code object.
+
+    """
+    if not (source_code / "Pipfile").is_file():
+        return False
+
+    if not (source_code / "Pipfile.lock").is_file():
+        LOGGER.warning("Pipfile.lock not found; creating it...")
+    return True

--- a/awslambda/python_requirements/dependency_managers/_poetry.py
+++ b/awslambda/python_requirements/dependency_managers/_poetry.py
@@ -1,4 +1,4 @@
-"""Poetry CLI interface."""
+"""Poetry interface."""
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -78,17 +78,13 @@ class TestPythonFunctionHookArgs:
 
     def test_extra(self, tmp_path: Path) -> None:
         """Test extra fields."""
-        with pytest.raises(ValidationError) as excinfo:
-            PythonFunctionHookArgs(
-                bucket_name="test-bucket",
-                function_name="name",
-                invalid=True,
-                source_code=tmp_path,
-            )
-        errors = excinfo.value.errors()
-        assert len(errors) == 1
-        assert errors[0]["loc"] == ("invalid",)
-        assert errors[0]["msg"] == "extra fields not permitted"
+        obj = PythonFunctionHookArgs(
+            bucket_name="test-bucket",
+            function_name="name",
+            invalid=True,
+            source_code=tmp_path,
+        )
+        assert not obj.get("invalid")
 
     def test_field_defaults(self, tmp_path: Path) -> None:
         """Test field defaults."""

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
@@ -1,0 +1,112 @@
+"""Test runway.cfngin.hooks.awslambda.python_requirements.dependency_managers._pipenv."""
+# pylint: disable=no-self-use,protected-access
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import TYPE_CHECKING, Any, Dict
+
+import pytest
+from mock import Mock
+
+from awslambda.python_requirements.dependency_managers._pipenv import (
+    Pipenv,
+    PipenvExportFailedError,
+    is_pipenv_project,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+class TestPipenv:
+    """Test pipenv."""
+
+    @pytest.mark.parametrize(
+        "export_kwargs",
+        [
+            {},
+            {
+                "dev": True,
+            },
+        ],
+    )
+    def test_export(
+        self,
+        export_kwargs: Dict[str, Any],
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test export."""
+        expected = tmp_path / "expected" / "test.requirements.txt"
+        mock_generate_command = mocker.patch.object(
+            Pipenv, "generate_command", return_value="generate_command"
+        )
+        mock_run_command = mocker.patch.object(
+            Pipenv, "_run_command", return_value="_run_command"
+        )
+        obj = Pipenv(Mock(), Mock(root_directory=tmp_path))
+        assert obj.export(output=expected, **export_kwargs) == expected
+        assert expected.is_file()
+        export_kwargs.setdefault("dev", False)
+        export_kwargs["requirements"] = True  # hardcoded in the method
+        mock_generate_command.assert_called_once_with("lock", **export_kwargs)
+        mock_run_command.assert_called_once_with(
+            mock_generate_command.return_value, suppress_output=True
+        )
+
+    def test_export_raise_from_called_process_error(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test export raise PoetryExportFailedError from CalledProcessError."""
+        output = tmp_path / "expected" / "test.requirements.txt"
+        mock_generate_command = mocker.patch.object(
+            Pipenv, "generate_command", return_value="generate_command"
+        )
+        mock_run_command = mocker.patch.object(
+            Pipenv,
+            "_run_command",
+            side_effect=subprocess.CalledProcessError(
+                returncode=1,
+                cmd=mock_generate_command.return_value,
+            ),
+        )
+
+        with pytest.raises(PipenvExportFailedError):
+            assert Pipenv(Mock(), Mock(root_directory=tmp_path)).export(output=output)
+        mock_run_command.assert_called_once_with(
+            mock_generate_command.return_value, suppress_output=True
+        )
+
+    def test_version(self, mocker: MockerFixture) -> None:
+        """Test version."""
+        mock_run_command = mocker.patch.object(
+            Pipenv, "_run_command", return_value="success"
+        )
+        assert Pipenv(Mock(), Mock()).version == mock_run_command.return_value
+        mock_run_command.assert_called_once_with([Pipenv.EXECUTABLE, "--version"])
+
+
+@pytest.mark.parametrize(
+    "lock_exists, pipfile_exists",
+    [(False, False), (False, True), (True, True), (True, False)],
+)
+def test_is_pipenv_project(
+    caplog: LogCaptureFixture, lock_exists: bool, pipfile_exists: bool, tmp_path: Path
+) -> None:
+    """Test is_pipenv_project."""
+    caplog.set_level(logging.WARNING)
+    if lock_exists:
+        (tmp_path / "Pipfile.lock").touch()
+    if pipfile_exists:
+        (tmp_path / "Pipfile").touch()
+        assert is_pipenv_project(tmp_path)
+        if not lock_exists:
+            assert "Pipfile.lock not found; creating it..." in caplog.messages
+    else:
+        assert not is_pipenv_project(tmp_path)


### PR DESCRIPTION
# Summary

Add support for projects using `pipenv`.

# What Changed

## Added

- added support for pipenv

## Changed

- extra fields are now ignored for python hook args instead of being forbiden
