### PR TITLE
remove function_name arg, include runtime in paths

### DIFF
--- a/awslambda/base_classes.py
+++ b/awslambda/base_classes.py
@@ -188,7 +188,9 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
     def build_directory(self) -> Path:
         """Directory being used to build deployment package."""
         result = (
-            BASE_WORK_DIR / f"{self.args.function_name}.{self.source_code.md5_hash}"
+            BASE_WORK_DIR
+            / self.runtime
+            / f"{self.source_code.root_directory.name}.{self.source_code.md5_hash}"
         )
         result.mkdir(exist_ok=True, parents=True)
         return result

--- a/awslambda/deployment_package.py
+++ b/awslambda/deployment_package.py
@@ -88,9 +88,9 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
     @cached_property
     def archive_file(self) -> Path:
         """Path to archive file."""
-        return (
-            self.project.build_directory
-            / f"{self.project.args.function_name}.{self.project.source_code.md5_hash}.zip"
+        return self.project.build_directory / (
+            f"{self.project.source_code.root_directory.name}."
+            f"{self.project.source_code.md5_hash}.zip"
         )
 
     @cached_property
@@ -154,7 +154,7 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
     @cached_property
     def object_key(self) -> str:
         """Key to use when upload object to AWS S3."""
-        prefix = "awslambda/functions"
+        prefix = f"awslambda/functions/{self.project.runtime}"
         if self.project.args.object_prefix:
             prefix = (
                 f"{prefix}/{self.project.args.object_prefix.lstrip('/').rstrip('/')}"

--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -19,7 +19,6 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
         extend_gitignore: gitignore rules that should be added to the rules
             already defined in a ``.gitignore`` file in the source code directory.
             This can be used with or without an existing file.
-        function_name: Name of the lambda function.
         object_prefix: Prefix to add to the S3 Object key.
         runtime: Runtime of the Lambda Function.
         source_code: Path to the Lambda Function source code.
@@ -28,7 +27,6 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
 
     bucket_name: str
     extend_gitignore: List[str] = []
-    function_name: str
     object_prefix: Optional[str] = None
     runtime: str
     source_code: DirectoryPath

--- a/tests/unit/cfngin/hooks/awslambda/factories.py
+++ b/tests/unit/cfngin/hooks/awslambda/factories.py
@@ -20,8 +20,9 @@ class MockProject(Project[AwsLambdaHookArgs]):
     def build_directory(self) -> Path:
         """Directory being used to build deployment package."""
         result = (
-            self.args.source_code
-            / f"{self.args.function_name}.{self.source_code.md5_hash}"
+            self.source_code
+            / self.runtime
+            / f"{self.source_code.root_directory.name}.{self.source_code.md5_hash}"
         )
         result.mkdir(exist_ok=True, parents=True)
         return result

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -20,7 +20,6 @@ class TestAwsLambdaHookArgs:
         """Test _resolve_path."""
         obj = AwsLambdaHookArgs(  # these are all required fields
             bucket_name="test-bucket",
-            function_name="name",
             runtime="test",
             source_code="./",
         )
@@ -31,7 +30,6 @@ class TestAwsLambdaHookArgs:
         """Test field defaults."""
         obj = AwsLambdaHookArgs(  # these are all required fields
             bucket_name="test-bucket",
-            function_name="name",
             runtime="test",
             source_code=tmp_path,
         )
@@ -45,7 +43,6 @@ class TestAwsLambdaHookArgs:
         with pytest.raises(ValidationError) as excinfo:
             AwsLambdaHookArgs(  # these are all required fields
                 bucket_name="test-bucket",
-                function_name="name",
                 runtime="test",
                 source_code=source_path,
             )
@@ -60,7 +57,6 @@ class TestAwsLambdaHookArgs:
         with pytest.raises(ValidationError) as excinfo:
             AwsLambdaHookArgs(  # these are all required fields
                 bucket_name="test-bucket",
-                function_name="name",
                 runtime="test",
                 source_code=source_path,
             )
@@ -80,7 +76,6 @@ class TestPythonFunctionHookArgs:
         """Test extra fields."""
         obj = PythonFunctionHookArgs(
             bucket_name="test-bucket",
-            function_name="name",
             invalid=True,
             source_code=tmp_path,
         )
@@ -90,7 +85,6 @@ class TestPythonFunctionHookArgs:
         """Test field defaults."""
         obj = PythonFunctionHookArgs(  # these are all required fields
             bucket_name="test-bucket",
-            function_name="name",
             source_code=tmp_path,
         )
         assert not obj.extend_pip_args

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -265,46 +265,42 @@ class TestProject:
         assert obj.args == args
         assert obj.ctx == cfngin_context
 
-    def test_build_directory(
-        self, cfngin_context: CfnginContext, mocker: MockerFixture, tmp_path: Path
-    ) -> None:
+    def test_build_directory(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test build_directory."""
-        mocker.patch.object(Project, "source_code", Mock(md5_hash="hash"))
+        mocker.patch.object(
+            Project, "source_code", Mock(md5_hash="hash", root_directory=tmp_path)
+        )
         mocker.patch(f"{MODULE}.BASE_WORK_DIR", tmp_path)
-        expected = tmp_path / "foo.hash"
+        expected = tmp_path / "bar" / f"{tmp_path.name}.hash"
 
-        obj = Project(Mock(function_name="foo"), cfngin_context)
+        obj = Project(Mock(runtime="bar"), Mock())
         assert obj.build_directory == expected
         assert expected.is_dir()
 
-    def test_cleanup(self, cfngin_context: CfnginContext) -> None:
+    def test_cleanup(self) -> None:
         """Test cleanup. Should do nothing."""
-        assert not Project(Mock(), cfngin_context).cleanup()
+        assert not Project(Mock(), Mock()).cleanup()
 
-    def test_dependency_directory(
-        self, cfngin_context: CfnginContext, mocker: MockerFixture, tmp_path: Path
-    ) -> None:
+    def test_dependency_directory(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test dependency_directory."""
         mocker.patch.object(Project, "build_directory", tmp_path)
         expected = tmp_path / "dependencies"
 
-        obj = Project(Mock(), cfngin_context)
+        obj = Project(Mock(), Mock())
         assert obj.dependency_directory == expected
         assert expected.is_dir()
 
-    def test_install_dependencies(self, cfngin_context: CfnginContext) -> None:
+    def test_install_dependencies(self) -> None:
         """Test install_dependencies."""
         with pytest.raises(NotImplementedError):
-            assert Project(Mock(), cfngin_context).install_dependencies()
+            assert Project(Mock(), Mock()).install_dependencies()
 
     def test_runtime(self) -> None:
         """Test runtime."""
         args = Mock(runtime="runtime")
         assert Project(args, Mock()).runtime == args.runtime
 
-    def test_source_code(
-        self, cfngin_context: CfnginContext, mocker: MockerFixture
-    ) -> None:
+    def test_source_code(self, mocker: MockerFixture) -> None:
         """Test source_code."""
         args = Mock(extend_gitignore=["rule0"], source_code="foo")
         source_code = Mock()
@@ -312,7 +308,7 @@ class TestProject:
             f"{MODULE}.SourceCode", Mock(return_value=source_code)
         )
 
-        obj = Project(args, cfngin_context)
+        obj = Project(args, Mock())
         assert obj.source_code == source_code
         source_code_base_class.assert_called_once_with(args.source_code)
         source_code.add_filter_rule.assert_called_once_with(args.extend_gitignore[0])

--- a/tests/unit/cfngin/hooks/awslambda/test_deployment_package.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_deployment_package.py
@@ -38,7 +38,6 @@ def project(cfngin_context: CfnginContext, tmp_path: Path) -> ProjectTypeAlias:
     """Mock project object."""
     args = AwsLambdaHookArgs(
         bucket_name="test-bucket",
-        function_name="test-function",
         runtime="foobar3.9",
         source_code=tmp_path,
     )
@@ -131,7 +130,7 @@ class TestDeploymentPackage:
         assert obj.archive_file.parent == project.build_directory
         assert (
             obj.archive_file.name
-            == f"{project.args.function_name}.{project.source_code.md5_hash}.zip"
+            == f"{project.source_code.root_directory.name}.{project.source_code.md5_hash}.zip"
         )
 
     def test_bucket(self, mocker: MockerFixture, project: ProjectTypeAlias) -> None:
@@ -328,10 +327,11 @@ class TestDeploymentPackage:
         obj = DeploymentPackage(project)
         if object_prefix:
             expected_prefix = (
-                f"awslambda/functions/{object_prefix.lstrip('/').rstrip('/')}"
+                f"awslambda/functions/{project.runtime}/"
+                f"{object_prefix.lstrip('/').rstrip('/')}"
             )
         else:
-            expected_prefix = "awslambda/functions"
+            expected_prefix = f"awslambda/functions/{project.runtime}"
         assert obj.object_key == f"{expected_prefix}/{obj.archive_file.name}"
 
     @pytest.mark.parametrize(

--- a/tests/unit/cfngin/hooks/awslambda/test_python.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_python.py
@@ -24,7 +24,6 @@ def args(tmp_path: Path) -> PythonFunctionHookArgs:
     """Fixture for creating default function args."""
     return PythonFunctionHookArgs(
         bucket_name="test-bucket",
-        function_name="test-function",
         runtime="python3.9",
         source_code=tmp_path,
     )


### PR DESCRIPTION
# Summary

Remove `function_name` from args (resolves #56) & include `runtime` in deployment package paths.

# What Changed

## Changed

- the value of `runtime` is now included in the various paths used by the hook

## Removed

- `function_name` is not longer an argument of this hook
