### PR TITLE
SourceCode can now include files in hash that are gitignored

### DIFF
--- a/awslambda/python_requirements/dependency_managers/_pip.py
+++ b/awslambda/python_requirements/dependency_managers/_pip.py
@@ -13,6 +13,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Tuple,
     Union,
     cast,
 )
@@ -46,6 +47,7 @@ class PipInstallFailedError(CfnginError):
 class Pip(DependencyManager):
     """pip CLI interface."""
 
+    CONFIG_FILES: Final[Tuple[Literal["requirements.txt"]]] = ("requirements.txt",)
     EXECUTABLE: Final[Literal["pip"]] = "pip"
 
     @cached_property
@@ -109,7 +111,7 @@ class Pip(DependencyManager):
 
 
 def is_pip_project(
-    source_code: Union[Path, SourceCode], *, file_name: str = "requirements.txt"
+    source_code: Union[Path, SourceCode], *, file_name: str = Pip.CONFIG_FILES[0]
 ) -> bool:
     """Determine if source code is a pip project.
 

--- a/awslambda/python_requirements/dependency_managers/_pipenv.py
+++ b/awslambda/python_requirements/dependency_managers/_pipenv.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Union
+from typing import TYPE_CHECKING, Any, Final, Tuple, Union
 
 from runway.cfngin.exceptions import CfnginError
 from runway.compat import cached_property
@@ -48,6 +48,10 @@ class PipenvNotFoundError(CfnginError):
 class Pipenv(DependencyManager):
     """Pipenv dependency manager."""
 
+    CONFIG_FILES: Final[Tuple[Literal["Pipfile"], Literal["Pipfile.lock"]]] = (
+        "Pipfile",
+        "Pipfile.lock",
+    )
     EXECUTABLE: Final[Literal["pipenv"]] = "pipenv"
 
     @cached_property
@@ -90,9 +94,9 @@ def is_pipenv_project(source_code: Union[Path, SourceCode]) -> bool:
         source_code: Source code object.
 
     """
-    if not (source_code / "Pipfile").is_file():
+    if not (source_code / Pipenv.CONFIG_FILES[0]).is_file():
         return False
 
-    if not (source_code / "Pipfile.lock").is_file():
-        LOGGER.warning("Pipfile.lock not found; creating it...")
+    if not (source_code / Pipenv.CONFIG_FILES[1]).is_file():
+        LOGGER.warning("%s not found; creating it...", Pipenv.CONFIG_FILES[1])
     return True

--- a/awslambda/python_requirements/dependency_managers/_poetry.py
+++ b/awslambda/python_requirements/dependency_managers/_poetry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Final, List, Optional, Tuple, Union
 
 import tomli
 from runway.cfngin.exceptions import CfnginError
@@ -51,6 +51,10 @@ class PoetryNotFoundError(CfnginError):
 class Poetry(DependencyManager):
     """Poetry dependency manager."""
 
+    CONFIG_FILES: Final[Tuple[Literal["poetry.lock"], Literal["pyproject.toml"]]] = (
+        "poetry.lock",
+        "pyproject.toml",
+    )
     EXECUTABLE: Final[Literal["poetry"]] = "poetry"
 
     @cached_property
@@ -111,7 +115,7 @@ def is_poetry_project(source_code: Union[Path, SourceCode]) -> bool:
         source_code: Source code object.
 
     """
-    pyproject_path = source_code / "pyproject.toml"
+    pyproject_path = source_code / Poetry.CONFIG_FILES[1]
 
     if not pyproject_path.is_file():
         return False

--- a/tests/unit/cfngin/hooks/awslambda/factories.py
+++ b/tests/unit/cfngin/hooks/awslambda/factories.py
@@ -27,4 +27,9 @@ class MockProject(Project[AwsLambdaHookArgs]):
         result.mkdir(exist_ok=True, parents=True)
         return result
 
+    @cached_property
+    def project_type(self) -> str:
+        """Type of project (e.g. poetry, yarn)."""
+        return "mock"
+
     install_dependencies = Mock(return_value=None)

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pip.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pip.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
 class TestPip:
     """Test Pip."""
 
+    def test_config_files(self) -> None:
+        """Test CONFIG_FILES."""
+        assert Pip.CONFIG_FILES == ("requirements.txt",)
+
     @pytest.mark.parametrize("command", ["test", ["test"]])
     def test_generate_command(
         self,

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
 class TestPipenv:
     """Test pipenv."""
 
+    def test_config_files(self) -> None:
+        """Test CONFIG_FILES."""
+        assert Pipenv.CONFIG_FILES == ("Pipfile", "Pipfile.lock")
+
     @pytest.mark.parametrize(
         "export_kwargs",
         [

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_poetry.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_poetry.py
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
 class TestPoetry:
     """Test Poetry."""
 
+    def test_config_files(self) -> None:
+        """Test CONFIG_FILES."""
+        assert Poetry.CONFIG_FILES == ("poetry.lock", "pyproject.toml")
+
     @pytest.mark.parametrize(
         "export_kwargs",
         [

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -295,6 +295,15 @@ class TestProject:
         with pytest.raises(NotImplementedError):
             assert Project(Mock(), Mock()).install_dependencies()
 
+    def test_metadata_files(self) -> None:
+        """Test metadata_files."""
+        assert Project(Mock(), Mock()).metadata_files == ()
+
+    def test_project_type(self) -> None:
+        """Test project_type."""
+        with pytest.raises(NotImplementedError):
+            assert Project(Mock(), Mock()).project_type
+
     def test_runtime(self) -> None:
         """Test runtime."""
         args = Mock(runtime="runtime")
@@ -303,6 +312,11 @@ class TestProject:
     def test_source_code(self, mocker: MockerFixture) -> None:
         """Test source_code."""
         args = Mock(extend_gitignore=["rule0"], source_code="foo")
+        metadata_files = mocker.patch.object(
+            Project,
+            "metadata_files",
+            ("foo", "bar"),
+        )
         source_code = Mock()
         source_code_base_class = mocker.patch(
             f"{MODULE}.SourceCode", Mock(return_value=source_code)
@@ -310,5 +324,7 @@ class TestProject:
 
         obj = Project(args, Mock())
         assert obj.source_code == source_code
-        source_code_base_class.assert_called_once_with(args.source_code)
+        source_code_base_class.assert_called_once_with(
+            args.source_code, include_files_in_hash=metadata_files
+        )
         source_code.add_filter_rule.assert_called_once_with(args.extend_gitignore[0])


### PR DESCRIPTION
# Summary

`SourceCode` can now include files in hash calculation even if they are gitignored. This is to allow configuration files, lock files, etc to be included in the hash that determines if the code has been updated without requiring it to be included in the deployment package.

# Why This Is Needed

resolves #62 

# What Changed

## Added

- added optional `include_files_in_hash` kwarg to `SourceCode` object instantiation to always include files in hash calculation
	- this must be provided during instantiation so that it can be assessed when iterating the object during calculation
- added `CONFIG_FILES` class var to the `DependencyManager` base class for easy references for file names
- added `metadata_files` cached property to the `Project` base class that can be implemented by subclasses to references metadata files that may be gitignored but should be included in the hash calculation of the source code
- added `project_type` abstract cached property to the `Project` base class
	- identifies the _subtype_ of the language specific project class without instantiating other objects
	- allows for the value to be used in the logic of other methods/properties
- added implementation for `PythonProject.metadata_files`
	- this replaces some of the logic used in `PythonProject.pipenv` & `PythonProject.poetry`
- added values to new class var `Pip.CONFIG_FILES`, `Pipenv.CONFIG_FILES`, and `Poetry.CONFIG_FILES`

## Changed

- `Project.source_code` cached property now passes `Project.metadata_files` to `SourceCode` as the `include_files_in_hash` kwarg
- updated some function/methods to use the new `CONFIG_FILES` class var of the python dependency manager classes
