### PR TITLE
add support for project config/metadata files outside of source dir

### DIFF
--- a/awslambda/python_requirements/dependency_managers/_poetry.py
+++ b/awslambda/python_requirements/dependency_managers/_poetry.py
@@ -99,7 +99,7 @@ class Poetry(DependencyManager):
                     without_hashes=without_hashes,
                 )
             )
-            requirements_txt = self.source_code.root_directory / output.name
+            requirements_txt = self.root_directory / output.name
             if requirements_txt.is_file():
                 output.parent.mkdir(exist_ok=True, parents=True)
                 return requirements_txt.rename(output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ force-exclude = '''
     \.eggs
   | \.git
   | \.mypy_cache
+  | \.runway
   | \.tox
   | \.venv
   | _build

--- a/tests/unit/cfngin/hooks/awslambda/factories.py
+++ b/tests/unit/cfngin/hooks/awslambda/factories.py
@@ -28,6 +28,11 @@ class MockProject(Project[AwsLambdaHookArgs]):
         return result
 
     @cached_property
+    def project_root(self) -> Path:
+        """Root directory of the project."""
+        return self.args.source_code
+
+    @cached_property
     def project_type(self) -> str:
         """Type of project (e.g. poetry, yarn)."""
         return "mock"

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pip.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pip.py
@@ -65,7 +65,7 @@ class TestPip:
         )
 
         assert (
-            Pip(Mock(), Mock()).install(requirements=requirements_txt, target=target)
+            Pip(Mock(), tmp_path).install(requirements=requirements_txt, target=target)
             == target
         )
         assert target.is_dir(), "target directory and parents created"
@@ -93,7 +93,7 @@ class TestPip:
         )
 
         with pytest.raises(PipInstallFailedError) as excinfo:
-            assert Pip(Mock(), Mock()).install(
+            assert Pip(Mock(), tmp_path).install(
                 requirements=requirements_txt, target=target
             )
         assert (
@@ -101,12 +101,12 @@ class TestPip:
             "review pip's output above to troubleshoot"
         )
 
-    def test_version(self, mocker: MockerFixture) -> None:
+    def test_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test version."""
         mock_run_command = mocker.patch.object(
             Pip, "_run_command", return_value="success"
         )
-        assert Pip(Mock(), Mock()).version == mock_run_command.return_value
+        assert Pip(Mock(), tmp_path).version == mock_run_command.return_value
         mock_run_command.assert_called_once_with([Pip.EXECUTABLE, "--version"])
 
 

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_pipenv.py
@@ -52,7 +52,7 @@ class TestPipenv:
         mock_run_command = mocker.patch.object(
             Pipenv, "_run_command", return_value="_run_command"
         )
-        obj = Pipenv(Mock(), Mock(root_directory=tmp_path))
+        obj = Pipenv(Mock(), tmp_path)
         assert obj.export(output=expected, **export_kwargs) == expected
         assert expected.is_file()
         export_kwargs.setdefault("dev", False)
@@ -82,17 +82,17 @@ class TestPipenv:
         )
 
         with pytest.raises(PipenvExportFailedError):
-            assert Pipenv(Mock(), Mock(root_directory=tmp_path)).export(output=output)
+            assert Pipenv(Mock(), tmp_path).export(output=output)
         mock_run_command.assert_called_once_with(
             mock_generate_command.return_value, suppress_output=True
         )
 
-    def test_version(self, mocker: MockerFixture) -> None:
+    def test_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test version."""
         mock_run_command = mocker.patch.object(
             Pipenv, "_run_command", return_value="success"
         )
-        assert Pipenv(Mock(), Mock()).version == mock_run_command.return_value
+        assert Pipenv(Mock(), tmp_path).version == mock_run_command.return_value
         mock_run_command.assert_called_once_with([Pipenv.EXECUTABLE, "--version"])
 
 

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_poetry.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/dependency_managers/test_poetry.py
@@ -57,7 +57,7 @@ class TestPoetry:
         )
         (tmp_path / "test.requirements.txt").touch()  # created by _run_command
 
-        obj = Poetry(Mock(), Mock(root_directory=tmp_path))
+        obj = Poetry(Mock(), tmp_path)
         assert obj.export(output=expected, **export_kwargs) == expected
         assert expected.is_file()
         export_kwargs.update({"output": expected.name})
@@ -93,7 +93,7 @@ class TestPoetry:
         )
 
         with pytest.raises(PoetryExportFailedError) as excinfo:
-            assert Poetry(Mock(), Mock(root_directory=tmp_path)).export(output=output)
+            assert Poetry(Mock(), tmp_path).export(output=output)
         assert (
             excinfo.value.message
             == "poetry export failed with the following output:\nstderr"
@@ -112,18 +112,18 @@ class TestPoetry:
         )
 
         with pytest.raises(PoetryExportFailedError) as excinfo:
-            assert Poetry(Mock(), Mock(root_directory=tmp_path)).export(output=output)
+            assert Poetry(Mock(), tmp_path).export(output=output)
         assert (
             excinfo.value.message
             == f"poetry export failed with the following output:\n{mock_run_command.return_value}"
         )
 
-    def test_version(self, mocker: MockerFixture) -> None:
+    def test_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test version."""
         mock_run_command = mocker.patch.object(
             Poetry, "_run_command", return_value="success"
         )
-        assert Poetry(Mock(), Mock()).version == mock_run_command.return_value
+        assert Poetry(Mock(), tmp_path).version == mock_run_command.return_value
         mock_run_command.assert_called_once_with([Poetry.EXECUTABLE, "--version"])
 
 


### PR DESCRIPTION
# Summary

Add support for project configuration/metadata files (e.g. pyproject.toml, Pipenv) to be maintained outside of the project directory (resolves #63 ).

# What Changed

## Added

- added `project_root` arg and attribute to `SourceCode` object
- added `project_root` cached property to `Project` base class which attempts to identify the intended project root directory
- added `supported_metadata_files` cached property to `Project` base class as an easy way to get a set of supported metadata files for the project
- added `supported_metadata_files` cached property override to `PythonProject` class to return a python specific set of metadata files for the project

## Changed

- `SourceCode.md5_hash` is now calculated relative to project root
- `DependencyManager` `source_code` arg is now `root_directory` and only accepts a `StrPath`
