### PR TITLE
fix issue causing hook to return a model instead of a dict

### DIFF
--- a/awslambda/_python.py
+++ b/awslambda/_python.py
@@ -46,6 +46,6 @@ class PythonFunction(FunctionHook[PythonProject]):
         """Run during the **pre_deploy** stage."""
         try:
             self.deployment_package.upload()
-            return self.build_response("deploy")
+            return self.build_response("deploy").dict(by_alias=True)
         finally:
             self.cleanup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awslambda"
-version = "0.1.0"
+version = "0.1.1"
 description = "Runway hook for AWS Lambda."
 authors = ["Kyle Finley <kyle@finley.sh>"]
 license = "Apache-2.0"

--- a/tests/unit/cfngin/hooks/awslambda/test_python.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_python.py
@@ -67,17 +67,19 @@ class TestPythonFunction:
         self, args: PythonFunctionHookArgs, mocker: MockerFixture
     ) -> None:
         """Test pre_deploy."""
+        model = Mock(dict=Mock(return_value="success"))
         build_response = mocker.patch.object(
-            PythonFunction, "build_response", return_value="success"
+            PythonFunction, "build_response", return_value=(model)
         )
         cleanup = mocker.patch.object(PythonFunction, "cleanup")
         deployment_package = mocker.patch.object(PythonFunction, "deployment_package")
         assert (
             PythonFunction(Mock(), **args.dict()).pre_deploy()
-            == build_response.return_value
+            == model.dict.return_value
         )
         deployment_package.upload.assert_called_once_with()
         build_response.assert_called_once_with("deploy")
+        model.dict.assert_called_once_with(by_alias=True)
         cleanup.assert_called_once_with()
 
     def test_pre_deploy_always_cleanup(


### PR DESCRIPTION
# Why This Is Needed

The hook was returning a pydantic model instead of a `Dict` which would prevent the response from being added to `hook_data` on the context object.

# What Changed

## Fixed

- fix issue causing hook to return a model instead of a dict
