### PR TITLE
add lookup for use with hook

### DIFF
--- a/awslambda/type_defs.py
+++ b/awslambda/type_defs.py
@@ -1,0 +1,16 @@
+"""Type definitions."""
+from __future__ import annotations
+
+from typing import Optional
+
+from typing_extensions import TypedDict
+
+
+class AwsLambdaHookDeployResponseTypedDict(TypedDict):
+    """Dict output of awslambda.models.response.AwsLambdaHookDeployResponse using aliases."""
+
+    CodeSha256: str
+    Runtime: str
+    S3Bucket: str
+    S3Key: str
+    S3ObjectVersion: Optional[str]

--- a/awslambda_lookup/__init__.py
+++ b/awslambda_lookup/__init__.py
@@ -1,0 +1,45 @@
+"""Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses.
+
+.. tip::
+  To this the awslambda lookup, add the following to a CFNgin config.
+
+  .. code-block:: yaml
+
+    lookups:
+      awslambda: awslambda_lookup.AwsLambdaLookup
+
+"""
+import sys
+
+from runway.cfngin.lookups.registry import register_lookup_handler
+
+from ._lookup import AwsLambdaLookup
+
+if sys.version_info < (3, 8):  # cov: ignore
+    # importlib.metadata is standard lib for python>=3.8, use backport
+    from importlib_metadata import (  # type: ignore # pylint: disable=E
+        PackageNotFoundError,
+        version,
+    )
+else:
+    from importlib.metadata import (  # type: ignore # pylint: disable=E
+        PackageNotFoundError,
+        version,
+    )
+
+__all__ = ["__version__", "AwsLambdaLookup"]
+
+# quick way to register everything with one line in the CFNgin config file
+register_lookup_handler(AwsLambdaLookup.CodeSha256.NAME, AwsLambdaLookup.CodeSha256)
+register_lookup_handler(AwsLambdaLookup.Runtime.NAME, AwsLambdaLookup.Runtime)
+register_lookup_handler(AwsLambdaLookup.S3Bucket.NAME, AwsLambdaLookup.S3Bucket)
+register_lookup_handler(AwsLambdaLookup.S3Key.NAME, AwsLambdaLookup.S3Key)
+register_lookup_handler(
+    AwsLambdaLookup.S3ObjectVersion.NAME, AwsLambdaLookup.S3ObjectVersion
+)
+
+try:  # cov: ignore
+    __version__ = version(__name__)
+except PackageNotFoundError:  # cov: ignore
+    # package is not installed
+    __version__ = "0.0.0"

--- a/awslambda_lookup/__init__.py
+++ b/awslambda_lookup/__init__.py
@@ -30,6 +30,7 @@ else:
 __all__ = ["__version__", "AwsLambdaLookup"]
 
 # quick way to register everything with one line in the CFNgin config file
+register_lookup_handler(AwsLambdaLookup.Code.NAME, AwsLambdaLookup.Code)
 register_lookup_handler(AwsLambdaLookup.CodeSha256.NAME, AwsLambdaLookup.CodeSha256)
 register_lookup_handler(AwsLambdaLookup.Runtime.NAME, AwsLambdaLookup.Runtime)
 register_lookup_handler(AwsLambdaLookup.S3Bucket.NAME, AwsLambdaLookup.S3Bucket)

--- a/awslambda_lookup/_lookup.py
+++ b/awslambda_lookup/_lookup.py
@@ -1,0 +1,291 @@
+"""Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
+
+from pydantic import ValidationError
+from runway.context import RunwayContext
+from runway.lookups.handlers.base import LookupHandler
+from runway.utils import load_object_from_string
+
+from awslambda.base_classes import AwsLambdaHook
+from awslambda.models.responses import AwsLambdaHookDeployResponse
+
+from .exceptions import CfnginOnlyLookupError
+
+if TYPE_CHECKING:
+    from runway.config import CfnginConfig
+    from runway.config.models.cfngin import CfnginHookDefinitionModel
+    from runway.context import CfnginContext
+
+LOGGER = logging.getLogger(f"runway.{__name__}")
+
+
+class AwsLambdaLookup(LookupHandler):
+    """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses.
+
+    .. important::
+        The :class:`~awslambda.base_classes.AwsLambdaHook` must be defined in
+        the current config file with a :attr:`~cfngin.hook.data_key`.
+
+    .. important::
+        This lookup does not support arguments.
+
+    """
+
+    NAME: ClassVar[str] = "awslambda"
+
+    @classmethod
+    def get_deployment_package_data(
+        cls, context: CfnginContext, data_key: str
+    ) -> AwsLambdaHookDeployResponse:
+        """Get the response of a :class:`~awslambda.base_classes.AwsLambdaHook` run.
+
+        Args:
+            context: CFNgin context object.
+            data_key: The value of the ``data_key`` field as assigned in a
+                Hook definition.
+
+        Returns:
+            The :class:`~awslambda.base_classes.AwsLambdaHook` response parsed
+            into a data model. This will come from hook data if it exists or it
+            will be calculated and added to hook data for future use.
+
+        Raises:
+            TypeError: The data stored in hook data does not align with the
+                expected data model.
+
+        """
+        if data_key not in context.hook_data:
+            LOGGER.debug("%s missing from hook_data; attempting to get value", data_key)
+            hook = cls.init_hook_class(
+                context, cls.get_required_hook_definition(context.config, data_key)
+            )
+            context.set_hook_data(data_key, hook.plan())
+        try:
+            return AwsLambdaHookDeployResponse.parse_obj(context.hook_data[data_key])
+        except ValidationError:
+            raise TypeError(
+                "expected hook_data of type AwsLambdaHookDeployResponseTypedDict; "
+                f"got {type(context.hook_data[data_key])}"
+            ) from None
+
+    @staticmethod
+    def get_required_hook_definition(
+        config: CfnginConfig, data_key: str
+    ) -> CfnginHookDefinitionModel:
+        """Get the required Hook definition from the CFNgin config.
+
+        Currently, this only supports finding the data_key in ONE stage.
+
+        Args:
+            config: CFNgin config being processed.
+            data_key: The value of the ``data_key`` field as assigned in a
+                Hook definition.
+
+        Returns:
+            The Hook definition set to use the provided ``data_key``.
+
+        Raises:
+            ValueError: Either a Hook definition was not found for the provided
+                ``data_key`` or, more than one was found.
+
+        """
+        hooks_with_data_key = [
+            hook_def
+            for hook_def in [
+                *config.pre_deploy,
+                *config.pre_destroy,
+                *config.post_deploy,
+                *config.post_destroy,
+            ]
+            if hook_def.data_key == data_key
+        ]
+        if not hooks_with_data_key:
+            raise ValueError("no hook found")
+        if len(hooks_with_data_key) > 1:
+            raise ValueError("more than one hook definition found with data_key")
+        return hooks_with_data_key.pop()
+
+    @staticmethod
+    def init_hook_class(
+        context: CfnginContext, hook_def: CfnginHookDefinitionModel
+    ) -> AwsLambdaHook[Any]:
+        """Initialize :class:`~awslambda.base_classes.AwsLambdaHook` subclass instance.
+
+        Args:
+            context: CFNgin context object.
+            hook_def: The :class:`~awslambda.base_classes.AwsLambdaHook` definition.
+
+        Returns:
+            The loaded AwsLambdaHook object.
+
+        """
+        kls = load_object_from_string(hook_def.path)
+        if not issubclass(kls, AwsLambdaHook):
+            raise TypeError(
+                "hook path must be a subclass of AwsLambdaHook to use this lookup"
+            )
+        return cast(AwsLambdaHook[Any], kls(context, **hook_def.args))
+
+    @classmethod
+    def handle(  # pylint: disable=arguments-differ
+        cls,
+        value: str,
+        context: Union[CfnginContext, RunwayContext],
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AwsLambdaHookDeployResponse:
+        """Retrieve metadata for an AWS Lambda deployment package.
+
+        Args:
+            value: Value to resolve.
+            context: The current context object.
+
+        Returns:
+            The full :class:`~awslambda.models.response.AwsLambdaHookDeployResponse`
+            data model.
+
+        """
+        if isinstance(context, RunwayContext):
+            raise CfnginOnlyLookupError(  # TODO make this an exception in the runway repo
+                cls.NAME
+            )
+        query, _ = cls.parse(value)
+        return cls.get_deployment_package_data(context, query)
+
+    class CodeSha256(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.CodeSha256"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> str:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation resource as the
+                ``CodeSha256`` property.
+
+            """
+            return AwsLambdaLookup.handle(value, context, *args, **kwargs).code_sha256
+
+    class Runtime(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.Runtime"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> str:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation resource as the
+                ``Runtime`` property.
+
+            """
+            return AwsLambdaLookup.handle(value, context, *args, **kwargs).runtime
+
+    class S3Bucket(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.S3Bucket"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> str:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation resource as the
+                ``S3Bucket`` property.
+
+            """
+            return AwsLambdaLookup.handle(value, context, *args, **kwargs).bucket_name
+
+    class S3Key(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.S3Key"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> str:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation resource as the
+                ``S3Key`` property.
+
+            """
+            return AwsLambdaLookup.handle(value, context, *args, **kwargs).object_key
+
+    class S3ObjectVersion(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.S3ObjectVersion"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Optional[str]:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation resource as the
+                ``S3ObjectVersion`` property.
+
+            """
+            return AwsLambdaLookup.handle(
+                value, context, *args, **kwargs
+            ).object_version_id
+
+
+TYPE_NAME = AwsLambdaLookup.NAME

--- a/awslambda_lookup/_lookup.py
+++ b/awslambda_lookup/_lookup.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from runway.context import RunwayContext
 from runway.lookups.handlers.base import LookupHandler
 from runway.utils import load_object_from_string
+from troposphere.awslambda import Code
 
 from awslambda.base_classes import AwsLambdaHook
 from awslambda.models.responses import AwsLambdaHookDeployResponse
@@ -155,6 +156,36 @@ class AwsLambdaLookup(LookupHandler):
         query, _ = cls.parse(value)
         return cls.get_deployment_package_data(context, query)
 
+    class Code(LookupHandler):
+        """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
+
+        NAME: ClassVar[str] = "awslambda.Code"
+
+        @classmethod
+        def handle(  # pylint: disable=arguments-differ
+            cls,
+            value: str,
+            context: Union[CfnginContext, RunwayContext],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Code:
+            """Retrieve metadata for an AWS Lambda deployment package.
+
+            Args:
+                value: Value to resolve.
+                context: The current context object.
+
+            Returns:
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Function.Code``.
+
+            """
+            return Code(
+                **AwsLambdaLookup.handle(value, context, *args, **kwargs).dict(
+                    by_alias=True, exclude={"CodeSha256", "Runtime"}, exclude_none=True
+                )
+            )
+
     class CodeSha256(LookupHandler):
         """Lookup for :class:`~awslambda.base_classes.AwsLambdaHook` responses."""
 
@@ -175,8 +206,8 @@ class AwsLambdaLookup(LookupHandler):
                 context: The current context object.
 
             Returns:
-                Value that can be passed into CloudFormation resource as the
-                ``CodeSha256`` property.
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Version.CodeSha256``.
 
             """
             return AwsLambdaLookup.handle(value, context, *args, **kwargs).code_sha256
@@ -201,8 +232,8 @@ class AwsLambdaLookup(LookupHandler):
                 context: The current context object.
 
             Returns:
-                Value that can be passed into CloudFormation resource as the
-                ``Runtime`` property.
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Function.Runtime``.
 
             """
             return AwsLambdaLookup.handle(value, context, *args, **kwargs).runtime
@@ -227,8 +258,8 @@ class AwsLambdaLookup(LookupHandler):
                 context: The current context object.
 
             Returns:
-                Value that can be passed into CloudFormation resource as the
-                ``S3Bucket`` property.
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Function.Code.S3Bucket``.
 
             """
             return AwsLambdaLookup.handle(value, context, *args, **kwargs).bucket_name
@@ -253,8 +284,8 @@ class AwsLambdaLookup(LookupHandler):
                 context: The current context object.
 
             Returns:
-                Value that can be passed into CloudFormation resource as the
-                ``S3Key`` property.
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Function.Code.S3Key``.
 
             """
             return AwsLambdaLookup.handle(value, context, *args, **kwargs).object_key
@@ -279,8 +310,8 @@ class AwsLambdaLookup(LookupHandler):
                 context: The current context object.
 
             Returns:
-                Value that can be passed into CloudFormation resource as the
-                ``S3ObjectVersion`` property.
+                Value that can be passed into CloudFormation property
+                ``AWS::Lambda::Function.Code.S3ObjectVersion``.
 
             """
             return AwsLambdaLookup.handle(

--- a/awslambda_lookup/exceptions.py
+++ b/awslambda_lookup/exceptions.py
@@ -1,0 +1,18 @@
+"""High-level exceptions."""
+from __future__ import annotations
+
+from runway.cfngin.exceptions import CfnginError
+
+
+class CfnginOnlyLookupError(CfnginError):
+    """Attempted to use a CFNgin lookup outside of CFNgin."""
+
+    lookup_name: str
+
+    def __init__(self, lookup_name: str) -> None:
+        """Instantiate class."""
+        self.lookup_name = lookup_name
+        self.message = (
+            f"attempted to use CFNgin only lookup {lookup_name} outside of CFNgin"
+        )
+        super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.1.1"
 description = "Runway hook for AWS Lambda."
 authors = ["Kyle Finley <kyle@finley.sh>"]
 license = "Apache-2.0"
+packages = [
+  { include = "awslambda" },
+  { include = "awslambda_lookup" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/tests/unit/cfngin/lookups/__init__.py
+++ b/tests/unit/cfngin/lookups/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/unit/cfngin/lookups/handlers/__init__.py
+++ b/tests/unit/cfngin/lookups/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/unit/cfngin/lookups/handlers/test_awslambda.py
+++ b/tests/unit/cfngin/lookups/handlers/test_awslambda.py
@@ -1,0 +1,393 @@
+"""Test runway.cfngin.lookups.handlers.awslambda."""
+# pylint: disable=no-self-use,protected-access,redefined-outer-name
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from mock import Mock
+from runway.config import CfnginConfig
+from runway.config.models.cfngin import (
+    CfnginConfigDefinitionModel,
+    CfnginHookDefinitionModel,
+)
+from troposphere.awslambda import Code
+
+from awslambda.base_classes import AwsLambdaHook
+from awslambda.models.responses import AwsLambdaHookDeployResponse
+from awslambda_lookup._lookup import AwsLambdaLookup
+from awslambda_lookup.exceptions import CfnginOnlyLookupError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from runway.context import CfnginContext, RunwayContext
+
+MODULE = "awslambda_lookup._lookup"
+
+
+@pytest.fixture(scope="function")
+def hook_data() -> AwsLambdaHookDeployResponse:
+    """Fixture for hook response data."""
+    return AwsLambdaHookDeployResponse(
+        bucket_name="bucket_name",
+        code_sha256="code_sha256",
+        object_key="object_key",
+        object_version_id="object_version_id",
+        runtime="runtime",
+    )
+
+
+class TestAwsLambdaLookup:
+    """Test AwsLambdaLookup."""
+
+    def test_get_deployment_package_data(
+        self, hook_data: AwsLambdaHookDeployResponse
+    ) -> None:
+        """Test get_deployment_package_data."""
+        data_key = "test.key"
+        assert (
+            AwsLambdaLookup.get_deployment_package_data(
+                Mock(hook_data={data_key: hook_data.dict(by_alias=True)}), data_key
+            )
+            == hook_data
+        )
+
+    def test_get_deployment_package_data_set_hook_data(
+        self,
+        cfngin_context: CfnginContext,
+        hook_data: AwsLambdaHookDeployResponse,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test get_deployment_package_data set hook_data when it's missing."""
+        data_key = "test.key"
+        hook = Mock(plan=Mock(return_value=hook_data.dict(by_alias=True)))
+        init_hook_class = mocker.patch.object(
+            AwsLambdaLookup, "init_hook_class", return_value=hook
+        )
+        get_required_hook_definition = mocker.patch.object(
+            AwsLambdaLookup, "get_required_hook_definition", return_value="hook_def"
+        )
+        assert (
+            AwsLambdaLookup.get_deployment_package_data(cfngin_context, data_key)
+            == hook_data
+        )
+        get_required_hook_definition.assert_called_once_with(
+            cfngin_context.config, data_key
+        )
+        init_hook_class.assert_called_once_with(
+            cfngin_context, get_required_hook_definition.return_value
+        )
+        hook.plan.assert_called_once_with()
+        assert cfngin_context.hook_data[data_key] == hook_data.dict(by_alias=True)
+
+    def test_get_deployment_package_data_raise_type_error(self) -> None:
+        """Test get_deployment_package_data."""
+        with pytest.raises(TypeError) as excinfo:
+            assert not AwsLambdaLookup.get_deployment_package_data(
+                Mock(hook_data={"test": {"invalid": True}}), "test"
+            )
+        assert "expected AwsLambdaHookDeployResponseTypedDict, not " in str(
+            excinfo.value
+        )
+
+    def test_get_required_hook_definition(self) -> None:
+        """Test get_required_hook_definition."""
+        data_key = "test.data"
+        expected_hook = CfnginHookDefinitionModel(data_key=data_key, path="foo.bar")
+        config = CfnginConfig(
+            CfnginConfigDefinitionModel(
+                namespace="test",
+                pre_deploy=[
+                    expected_hook,
+                    CfnginHookDefinitionModel(data_key="foo", path="foo"),
+                ],
+                pre_destroy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="pre_destroy")
+                ],
+                post_deploy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="post_deploy")
+                ],
+                post_destroy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="post_destroy")
+                ],
+            )
+        )
+        assert (
+            AwsLambdaLookup.get_required_hook_definition(config, data_key)
+            == expected_hook
+        )
+
+    def test_get_required_hook_definition_raise_value_error_more_than_one(self) -> None:
+        """Test get_required_hook_definition raise ValueError for more than one."""
+        data_key = "test.data"
+        expected_hook = CfnginHookDefinitionModel(data_key=data_key, path="foo.bar")
+        config = CfnginConfig(
+            CfnginConfigDefinitionModel(
+                namespace="test",
+                pre_deploy=[expected_hook, expected_hook],
+            )
+        )
+        with pytest.raises(ValueError) as excinfo:
+            assert not AwsLambdaLookup.get_required_hook_definition(config, data_key)
+        assert (
+            str(excinfo.value)
+            == f"more than one hook definition found with data_key {data_key}"
+        )
+
+    def test_get_required_hook_definition_raise_value_error_none(self) -> None:
+        """Test get_required_hook_definition raise ValueError none found."""
+        data_key = "test.data"
+        config = CfnginConfig(
+            CfnginConfigDefinitionModel(
+                namespace="test",
+                pre_deploy=[
+                    CfnginHookDefinitionModel(data_key="foo", path="foo"),
+                ],
+                pre_destroy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="pre_destroy")
+                ],
+                post_deploy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="post_deploy")
+                ],
+                post_destroy=[
+                    CfnginHookDefinitionModel(data_key=data_key, path="post_destroy")
+                ],
+            )
+        )
+        with pytest.raises(ValueError) as excinfo:
+            assert not AwsLambdaLookup.get_required_hook_definition(config, data_key)
+        assert (
+            str(excinfo.value) == f"no hook definition found with data_key {data_key}"
+        )
+
+    def test_handle(self, mocker: MockerFixture) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_get_deployment_package_data = mocker.patch.object(
+            AwsLambdaLookup, "get_deployment_package_data", return_value="success"
+        )
+        mock_parse = mocker.patch.object(
+            AwsLambdaLookup, "parse", return_value=("query", {})
+        )
+        assert (
+            AwsLambdaLookup.handle("test", context)
+            == mock_get_deployment_package_data.return_value
+        )
+        mock_parse.assert_called_once_with("test")
+        mock_get_deployment_package_data.assert_called_once_with(
+            context, mock_parse.return_value[0]
+        )
+
+    def test_handle_raise_cfngin_only_lookup_error(
+        self, runway_context: RunwayContext
+    ) -> None:
+        """Test handle raise CfnginOnlyLookupError."""
+        with pytest.raises(CfnginOnlyLookupError):
+            AwsLambdaLookup.handle("test", runway_context)
+
+    def test_init_hook_class(self, mocker: MockerFixture) -> None:
+        """Test init_hook_class."""
+        context = Mock()
+        hook_class = Mock(return_value="success")
+        hook_def = Mock(args={"foo": "var"}, path="foo.bar")
+        load_object_from_string = mocker.patch(
+            f"{MODULE}.load_object_from_string", return_value=hook_class
+        )
+        mock_hasattr = mocker.patch(f"{MODULE}.hasattr", return_value=True)
+        mock_issubclass = mocker.patch(f"{MODULE}.issubclass", return_value=True)
+        assert (
+            AwsLambdaLookup.init_hook_class(context, hook_def)
+            == hook_class.return_value
+        )
+        load_object_from_string.assert_called_once_with(hook_def.path)
+        mock_hasattr.assert_called_once_with(hook_class, "__subclasscheck__")
+        mock_issubclass.assert_called_once_with(hook_class, AwsLambdaHook)
+        hook_class.assert_called_once_with(context, **hook_def.args)
+
+    def test_init_hook_class_raise_type_error_not_class(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test init_hook_class raise TypeError not a class."""
+
+        def _test_func() -> None:
+            pass
+
+        context = Mock()
+        hook_def = Mock(data_key="test", path="foo.bar")
+        mocker.patch(f"{MODULE}.load_object_from_string", return_value=_test_func)
+        with pytest.raises(TypeError) as excinfo:
+            AwsLambdaLookup.init_hook_class(context, hook_def)
+        assert str(excinfo.value) == (
+            f"hook path {hook_def.path} for hook with data_key {hook_def.data_key} "
+            "must be a subclass of AwsLambdaHook to use this lookup"
+        )
+
+    def test_init_hook_class_raise_type_error_not_subclass(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test init_hook_class raise TypeError not a class."""
+        hook_class = Mock(return_value="success")
+        context = Mock()
+        hook_def = Mock(data_key="test", path="foo.bar")
+        mocker.patch(f"{MODULE}.load_object_from_string", return_value=hook_class)
+        mocker.patch(f"{MODULE}.hasattr", return_value=True)
+        mocker.patch(f"{MODULE}.issubclass", return_value=False)
+        with pytest.raises(TypeError) as excinfo:
+            AwsLambdaLookup.init_hook_class(context, hook_def)
+        assert str(excinfo.value) == (
+            f"hook path {hook_def.path} for hook with data_key {hook_def.data_key} "
+            "must be a subclass of AwsLambdaHook to use this lookup"
+        )
+
+
+class TestTestAwsLambdaLookupCode:
+    """Test TestAwsLambdaLookup.Code."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        result = AwsLambdaLookup.Code.handle("test", context, "arg", foo="bar")
+        assert isinstance(result, Code)
+        assert not hasattr(result, "ImageUri")
+        assert result.S3Bucket == hook_data.bucket_name
+        assert result.S3Key == hook_data.object_key
+        assert result.S3ObjectVersion == hook_data.object_version_id
+        assert not hasattr(result, "ZipFile")
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.Code.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.Code.__name__}"
+        )
+
+
+class TestTestAwsLambdaLookupCodeSha256:
+    """Test TestAwsLambdaLookup.CodeSha256."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        assert (
+            AwsLambdaLookup.CodeSha256.handle("test", context, "arg", foo="bar")
+            == hook_data.code_sha256
+        )
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.CodeSha256.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.CodeSha256.__name__}"
+        )
+
+
+class TestTestAwsLambdaLookupRuntime:
+    """Test TestAwsLambdaLookup.Runtime."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        assert (
+            AwsLambdaLookup.Runtime.handle("test", context, "arg", foo="bar")
+            == hook_data.runtime
+        )
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.Runtime.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.Runtime.__name__}"
+        )
+
+
+class TestTestAwsLambdaLookupS3Bucket:
+    """Test TestAwsLambdaLookup.S3Bucket."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        assert (
+            AwsLambdaLookup.S3Bucket.handle("test", context, "arg", foo="bar")
+            == hook_data.bucket_name
+        )
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.S3Bucket.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.S3Bucket.__name__}"
+        )
+
+
+class TestTestAwsLambdaLookupS3Key:
+    """Test TestAwsLambdaLookup.S3Key."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        assert (
+            AwsLambdaLookup.S3Key.handle("test", context, "arg", foo="bar")
+            == hook_data.object_key
+        )
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.S3Key.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.S3Key.__name__}"
+        )
+
+
+class TestTestAwsLambdaLookupS3ObjectVersion:
+    """Test TestAwsLambdaLookup.S3ObjectVersion."""
+
+    def test_handle(
+        self, hook_data: AwsLambdaHookDeployResponse, mocker: MockerFixture
+    ) -> None:
+        """Test handle."""
+        context = Mock()
+        mock_handle = mocker.patch.object(
+            AwsLambdaLookup, "handle", return_value=hook_data
+        )
+        assert (
+            AwsLambdaLookup.S3ObjectVersion.handle("test", context, "arg", foo="bar")
+            == hook_data.object_version_id
+        )
+        mock_handle.assert_called_once_with("test", context, "arg", foo="bar")
+
+    def test_name(self) -> None:
+        """Test NAME."""
+        assert (
+            AwsLambdaLookup.S3ObjectVersion.NAME
+            == f"{AwsLambdaLookup.NAME}.{AwsLambdaLookup.S3ObjectVersion.__name__}"
+        )


### PR DESCRIPTION
# Summary

Add lookup designed to be used with the awslambda hook.

# What Changed

## Added

- added `awslambda_lookup` package
- added `awslambda.type_defs` submodule
- added `awslambda.base_classes.AwsLambdaHook.plan()` methods

## Changed

- `awslambda.base_classes.AwsLambdaHook.build_response()` method now accepts `"plan"` as input
	- response is similar to that of `"build"` but, if the archive files does not exist a placeholder value is used in place of it's SHA256 hash
