### PR TITLE
split out cli interface methods into a mixin for reuse

### DIFF
--- a/awslambda/mixins.py
+++ b/awslambda/mixins.py
@@ -1,0 +1,142 @@
+"""Class mixins."""
+from __future__ import annotations
+
+import logging
+import shlex
+import shutil
+import subprocess
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+    overload,
+)
+
+from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from runway._logging import RunwayLogger
+    from runway.context import CfnginContext, RunwayContext
+
+LOGGER = cast("RunwayLogger", logging.getLogger(f"runway.{__name__}"))
+
+
+class CliInterfaceMixin:
+    """Mixin for adding CLI interface methods."""
+
+    EXECUTABLE: ClassVar[str]  #: CLI executable.
+
+    ctx: Union[CfnginContext, RunwayContext]  #: CFNgin or Runway context object.
+    cwd: Path  #: Working directory where commands will be run.
+
+    @staticmethod
+    def convert_to_cli_arg(arg_name: str, *, prefix: str = "--") -> str:
+        """Convert string kwarg name into a CLI argument."""
+        return f"{prefix}{arg_name.replace('_', '-')}"
+
+    @classmethod
+    def found_in_path(cls) -> bool:
+        """Determine if executable is found in $PATH."""
+        if shutil.which(cls.EXECUTABLE):
+            return True
+        return False
+
+    @classmethod
+    def generate_command(
+        cls,
+        command: Union[List[str], str],
+        **kwargs: Optional[Union[bool, Sequence[str], str]],
+    ) -> List[str]:
+        """Generate command to be executed and log it.
+
+        Args:
+            command: Command to run.
+            args: Additional args to pass to the command.
+
+        Returns:
+            The full command to be passed into a subprocess.
+
+        """
+        cmd = [cls.EXECUTABLE, *(command if isinstance(command, list) else [command])]
+        cmd.extend(cls._generate_command_handle_kwargs(**kwargs))
+        LOGGER.debug("generated command: %s", shlex.join(cmd))
+        return cmd
+
+    @classmethod
+    def _generate_command_handle_kwargs(
+        cls, **kwargs: Optional[Union[bool, Sequence[str], str]]
+    ) -> List[str]:
+        """Handle kwargs passed to generate_command."""
+        result: List[str] = []
+        for k, v in kwargs.items():
+            if isinstance(v, str):
+                result.extend([cls.convert_to_cli_arg(k), v])
+            elif isinstance(v, (list, set, tuple)):
+                for i in cast(Sequence[str], v):
+                    result.extend([cls.convert_to_cli_arg(k), i])
+            elif isinstance(v, bool) and v:
+                result.append(cls.convert_to_cli_arg(k))
+        return result
+
+    @overload
+    def _run_command(
+        self,
+        command: Union[Sequence[str], str],
+        *,
+        env: Optional[Dict[str, str]] = ...,
+        suppress_output: Literal[True] = ...,
+    ) -> str:
+        ...
+
+    @overload
+    def _run_command(
+        self,
+        command: Union[Sequence[str], str],
+        *,
+        env: Optional[Dict[str, str]] = ...,
+        suppress_output: Literal[False] = ...,
+    ) -> None:
+        ...
+
+    def _run_command(
+        self,
+        command: Union[Sequence[str], str],
+        *,
+        env: Optional[Dict[str, str]] = None,
+        suppress_output: bool = True,
+    ) -> Optional[str]:
+        """Run command.
+
+        Args:
+            command: Command to pass to shell to execute.
+            env: Environment variables.
+            suppress_output: If ``True``, the output of the subprocess written
+                to ``sys.stdout`` and ``sys.stderr`` will be captured and
+                returned as a string instead of being being written directly.
+
+        """
+        cmd_str = command if isinstance(command, str) else shlex.join(command)
+        LOGGER.verbose("running command: %s", cmd_str)
+        if suppress_output:
+            return subprocess.check_output(
+                cmd_str,
+                cwd=self.cwd,
+                env=env or self.ctx.env.vars,
+                shell=True,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        subprocess.check_call(
+            cmd_str,
+            cwd=self.cwd,
+            env=env or self.ctx.env.vars,
+            shell=True,
+        )
+        return None

--- a/awslambda/python_requirements/dependency_managers/_poetry.py
+++ b/awslambda/python_requirements/dependency_managers/_poetry.py
@@ -99,7 +99,7 @@ class Poetry(DependencyManager):
                     without_hashes=without_hashes,
                 )
             )
-            requirements_txt = self.root_directory / output.name
+            requirements_txt = self.cwd / output.name
             if requirements_txt.is_file():
                 output.parent.mkdir(exist_ok=True, parents=True)
                 return requirements_txt.rename(output)

--- a/tests/unit/cfngin/hooks/awslambda/test_mixins.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_mixins.py
@@ -1,0 +1,124 @@
+"""Test runway.cfngin.hooks.awslambda.mixins."""
+# pylint: disable=no-self-use,protected-access
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import pytest
+from mock import Mock
+
+from awslambda.mixins import CliInterfaceMixin
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+    from runway.context import CfnginContext
+
+MODULE = "awslambda.mixins"
+
+
+class CliInterface(CliInterfaceMixin):
+    """Used in tests."""
+
+    def __init__(self, context: CfnginContext, cwd: Path) -> None:
+        """Instantiate class."""
+        self.ctx = context
+        self.cwd = cwd
+
+
+class TestCliInterfaceMixin:
+    """Test CliInterfaceMixin."""
+
+    @pytest.mark.parametrize("env", [None, {"foo": "bar"}])
+    def test__run_command(
+        self, env: Optional[Dict[str, str]], mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test _run_command."""
+        ctx_env = {"foo": "bar", "bar": "foo"}
+        mock_subprocess = mocker.patch(
+            f"{MODULE}.subprocess.check_output", return_value="success"
+        )
+        assert (
+            CliInterface(Mock(env=Mock(vars=ctx_env)), tmp_path)._run_command(
+                "test", env=env
+            )
+            == mock_subprocess.return_value
+        )
+        mock_subprocess.assert_called_once_with(
+            "test",
+            cwd=tmp_path,
+            env=env or ctx_env,
+            shell=True,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test__run_command_no_suppress_output(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test _run_command."""
+        env = {"foo": "bar"}
+        mock_subprocess = mocker.patch(
+            f"{MODULE}.subprocess.check_call", return_value=0
+        )
+        assert not CliInterface(Mock(env=Mock(vars=env)), tmp_path)._run_command(
+            ["foo", "bar"], suppress_output=False
+        )
+        mock_subprocess.assert_called_once_with(
+            "foo bar",
+            cwd=tmp_path,
+            env=env,
+            shell=True,
+        )
+
+    @pytest.mark.parametrize(
+        "prefix, provided, expected",
+        [
+            (None, "foo", "--foo"),
+            ("-", "foo_bar", "-foo-bar"),
+            ("--", "foo-bar", "--foo-bar"),
+        ],
+    )
+    def test_convert_to_cli_arg(
+        self, expected: str, prefix: Optional[str], provided: str
+    ) -> None:
+        """Test convert_to_cli_arg."""
+        if prefix:
+            assert CliInterface.convert_to_cli_arg(provided, prefix=prefix) == expected
+        else:
+            assert CliInterface.convert_to_cli_arg(provided) == expected
+
+    @pytest.mark.parametrize("return_value", [False, True])
+    def test_found_in_path(self, mocker: MockerFixture, return_value: bool) -> None:
+        """Test found_in_path."""
+        exe = mocker.patch.object(CliInterface, "EXECUTABLE", "foo.exe", create=True)
+        mock_which = Mock(return_value=return_value)
+        mocker.patch(f"{MODULE}.shutil", which=mock_which)
+        assert CliInterface.found_in_path() is return_value
+        mock_which.assert_called_once_with(exe)
+
+    @pytest.mark.parametrize(
+        "provided, expected",
+        [
+            ({}, []),
+            ({"is_flag": True}, ["--is-flag"]),
+            ({"is_flag": False}, []),
+            ({"key": "val", "is-flag": True}, ["--key", "val", "--is-flag"]),
+            ({"user": ["foo", "bar"]}, ["--user", "foo", "--user", "bar"]),
+        ],
+    )
+    def test_generate_command(
+        self,
+        expected: List[str],
+        mocker: MockerFixture,
+        provided: Dict[str, Any],
+    ) -> None:
+        """Test generate_command."""
+        exe = mocker.patch.object(CliInterface, "EXECUTABLE", "test.exe", create=True)
+        assert CliInterface.generate_command("command", **provided) == [
+            exe,
+            "command",
+            *expected,
+        ]


### PR DESCRIPTION
# Summary

Created a mixin class for CLI interface classes.

# What Changed

## Added

- added `awslambda.mixins.CliInterfaceMixin`

## Changed

- `awslambda.base_classes.DependencyManager` now inherits from `awslambda.mixins.CliInterfaceMixin`
