### PR TITLE
project metadata files are no longer required

### DIFF
--- a/docs/source/hooks/python/function.rst
+++ b/docs/source/hooks/python/function.rst
@@ -6,10 +6,10 @@ This hook creates deployment packages for Python Lambda Functions, uploads them 
 
 The return value can be retrieved using the :ref:`hook_data Lookup <hook_data lookup>` or by interacting with the :class:`~runway.context.CfnginContext` object passed to the |Blueprint|.
 
-To use this hook, it must be able to find project metadata files.
+To use this hook to install dependencies, it must be able to find project metadata files.
 This can include ``Pipefile`` & ``Pipfile.lock`` files (pipenv), a ``pyproject.toml`` & ``poetry.lock`` files (poetry), or a ``requirements.txt`` file (pip).
 The project metadata files can exist either in the source code directory (value of ``source_code`` arg) or in the same directory as the CFNgin configuration file.
-These files are required to defined the dependencies that will be included in the deployment package.
+If metadata files are not found, dependencies will not be included in the deployment package.
 
 This hook will always use Docker to install/compile dependencies unless explicitly configured not to.
 It is recommended to always use Docker to ensure a clean and consistent build.

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test_python_docker.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test_python_docker.py
@@ -85,6 +85,15 @@ class TestPythonDockerDependencyInstaller:
             mock_generate_install_command.return_value + args.extend_pip_args
         )
 
+    def test_install_commands_no_requirements(self) -> None:
+        """Test install_commands no requirements."""
+        assert (
+            PythonDockerDependencyInstaller(
+                Mock(requirements_txt=None), client=Mock()
+            ).install_commands
+            == []
+        )
+
     def test_python_version(self, mocker: MockerFixture) -> None:
         """Test python_version."""
         version = "3.10.0"


### PR DESCRIPTION
# Why This Is Needed

Some projects may not need external dependencies.

# What Changed

## Changed

- an error is no longer raised if project metadata files are not found
	- if no metadata files are found dependency install is skipped
