### PR TITLE
convert object version id `"null"` strong to `NoneType`

### DIFF
--- a/awslambda/deployment_package.py
+++ b/awslambda/deployment_package.py
@@ -465,7 +465,8 @@ class DeploymentPackageS3Object(DeploymentPackage[_ProjectTypeVar]):
         """
         if not self.head or "VersionId" not in self.head:
             return None
-        return self.head["VersionId"]
+        version_id = self.head["VersionId"]
+        return version_id if version_id != "null" else None
 
     @cached_property
     def runtime(self) -> str:


### PR DESCRIPTION
# Why This Is Needed

When using `.head_object()` for an S3 object that is not versioned, the `VersionId` is `Literal["null"]`. This results in the value differing from what the hook/lookup (`.put_object()`) returns when the object is first created and what the hook/lookup returns for subsequent runs. Converting the `Literal["null"]` value to `Literal[None]` avoids this.
