### PR TITLE
rebuild deployment package if runtime is changed

### DIFF
--- a/awslambda/_python.py
+++ b/awslambda/_python.py
@@ -44,7 +44,7 @@ class PythonFunction(FunctionHook[PythonProject]):
 
     def cleanup_on_error(self) -> None:
         """Cleanup after an error has occurred."""
-        self.deployment_package.archive_file.unlink(missing_ok=True)
+        self.deployment_package.delete()
         self.project.cleanup_on_error()
 
     def pre_deploy(self) -> Any:

--- a/awslambda/deployment_package.py
+++ b/awslambda/deployment_package.py
@@ -7,7 +7,6 @@ import logging
 import mimetypes
 import stat
 import zipfile
-from contextlib import suppress
 from typing import (
     TYPE_CHECKING,
     ClassVar,
@@ -33,7 +32,9 @@ from .exceptions import (
     BucketNotFoundError,
     DeploymentPackageEmptyError,
     RequiredTagNotFoundError,
+    S3ObjectDoesNotExistError,
 )
+from .mixins import DelCachedPropMixin
 from .models.args import AwsLambdaHookArgs
 
 if TYPE_CHECKING:
@@ -49,7 +50,7 @@ LOGGER = cast("RunwayLogger", logging.getLogger(f"runway.{__name__}"))
 _ProjectTypeVar = TypeVar("_ProjectTypeVar", bound=Project[AwsLambdaHookArgs])
 
 
-class DeploymentPackage(Generic[_ProjectTypeVar]):
+class DeploymentPackage(DelCachedPropMixin, Generic[_ProjectTypeVar]):
     """AWS Lambda Deployment Package.
 
     When interacting with subclass of this instance, it is recommended to
@@ -209,12 +210,8 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
         if self.archive_file.stat().st_size <= self.SIZE_EOCD:
             raise DeploymentPackageEmptyError(self.archive_file)
 
-        # clear cached properties so they can recalculate;
-        # handles cached property not being resolved yet
-        with suppress(AttributeError):
-            del self.code_sha256
-        with suppress(AttributeError):
-            del self.md5_checksum
+        # clear cached properties so they can recalculate
+        self._del_cached_property("code_sha256", "exists", "md5_checksum")
         return self.archive_file
 
     def _build_fix_file_permissions(self, archive_file: zipfile.ZipFile) -> None:
@@ -296,6 +293,15 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
             return urlencode(tags)
         return tags
 
+    def delete(self) -> None:
+        """Delete deployment package."""
+        self.archive_file.unlink(missing_ok=True)
+        LOGGER.verbose("deleted local deployment package %s", self.archive_file)
+        # clear cached properties so they can recalculate
+        self._del_cached_property(
+            "code_sha256", "exists", "md5_checksum", "object_version_id"
+        )
+
     def iterate_dependency_directory(self) -> Iterator[Path]:
         """Iterate over the contents of the dependency directory.
 
@@ -336,11 +342,8 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
             Key=self.object_key,
             Tagging=self.build_tag_set(),
         )
-
-        # clear cached properties so they can recalculate;
-        # handles cached property not being resolved yet
-        with suppress(AttributeError):
-            del self.object_version_id
+        # clear cached properties so they can recalculate
+        self._del_cached_property("object_version_id")
 
     @classmethod
     def init(cls, project: _ProjectTypeVar) -> DeploymentPackage[_ProjectTypeVar]:
@@ -360,7 +363,15 @@ class DeploymentPackage(Generic[_ProjectTypeVar]):
         """
         s3_obj = DeploymentPackageS3Object(project)
         if s3_obj.exists:
-            return s3_obj
+            if s3_obj.runtime == project.runtime:
+                return s3_obj
+            LOGGER.warning(
+                "runtime of deployment package found in S3 (%s) does not match "
+                "requirement (%s); deleting & recreating...",
+                s3_obj.runtime,
+                project.runtime,
+            )
+            s3_obj.delete()
         return cls(project)
 
 
@@ -484,18 +495,60 @@ class DeploymentPackageS3Object(DeploymentPackage[_ProjectTypeVar]):
         return self.object_tags[self.META_TAGS["runtime"]]
 
     def build(self) -> Path:
-        """Build the deployment package."""
+        """Build the deployment package.
+
+        The object should already exist. This method only exists as a "placeholder"
+        to match the parent class. If the object does not already exist, and
+        error is raised.
+
+        Raises:
+            S3ObjectDoesNotExistError: The S3 object does not exist.
+
+        """
+        if not self.exists:
+            raise S3ObjectDoesNotExistError(self.bucket.name, self.object_key)
         LOGGER.info("build skipped; %s already exists", self.archive_file.name)
         return self.archive_file
 
+    def delete(self) -> None:
+        """Delete deployment package."""
+        if self.exists:
+            self.bucket.client.delete_object(
+                Bucket=self.bucket.name, Key=self.object_key
+            )
+            LOGGER.verbose(
+                "deleted deployment package S3 object %s",
+                self.bucket.format_bucket_path_uri(key=self.object_key),
+            )
+            # clear cached properties so they can recalculate
+            self._del_cached_property(
+                "code_sha256",
+                "exists",
+                "md5_checksum",
+                "object_tags",
+                "object_version_id",
+                "runtime",
+            )
+        self.archive_file.unlink(missing_ok=True)
+        LOGGER.verbose("deleted local deployment package %s", self.archive_file)
+
     def upload(self, *, build: bool = True) -> None:  # pylint: disable=unused-argument
         """Upload deployment package.
+
+        The object should already exist. This method only exists as a "placeholder"
+        to match the parent class. If the object does not already exist, and
+        error is raised.
 
         Args:
             build: If true, the deployment package will be built before before
                 trying to upload it. If false, it must have already been built.
 
+        Raises:
+            S3ObjectDoesNotExistError: The S3 object does not exist.
+
         """
+        if not self.exists:
+            raise S3ObjectDoesNotExistError(self.bucket.name, self.object_key)
         LOGGER.info(
             "upload skipped; %s already exists",
             self.bucket.format_bucket_path_uri(key=self.object_key),

--- a/awslambda/exceptions.py
+++ b/awslambda/exceptions.py
@@ -70,6 +70,7 @@ class DeploymentPackageEmptyError(CfnginError):
             archive_file: The empty archive file.
 
         """
+        self.archive_file = archive_file
         self.message = f"{archive_file.name} contains no files"
         super().__init__()
 
@@ -169,4 +170,26 @@ class RuntimeMismatchError(CfnginError):
             f"{detected_runtime} runtime determined from the build system"
             f" does not match the expected {expected_runtime} runtime"
         )
+        super().__init__()
+
+
+class S3ObjectDoesNotExistError(CfnginError):  # TODO should this be a RunwayError?
+    """Required S3 object does not exist."""
+
+    bucket: str
+    key: str
+    uri: str
+
+    def __init__(self, bucket: str, key: str) -> None:
+        """Instantiate class.
+
+        Args:
+            bucket: Name of the S3 bucket.
+            key: S3 object key.
+
+        """
+        self.bucket = bucket
+        self.key = key
+        self.uri = f"s3://{bucket}/{key.lstrip('/')}"
+        self.message = f"S3 object does not exist at path {self.uri}"
         super().__init__()

--- a/awslambda/mixins.py
+++ b/awslambda/mixins.py
@@ -6,6 +6,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+from contextlib import suppress
 from typing import (
     TYPE_CHECKING,
     ClassVar,
@@ -152,3 +153,18 @@ class CliInterfaceMixin:
             shell=True,
         )
         return None
+
+
+class DelCachedPropMixin:
+    """Mixin to handle safely clearing the value of :func:`functools.cached_property`."""
+
+    def _del_cached_property(self, *names: str) -> None:
+        """Delete the cached value of a :func:`functools.cached_property`.
+
+        Args:
+            names: Names of the attribute that is cached. Can provide one or multiple.
+
+        """
+        for name in names:
+            with suppress(AttributeError):
+                delattr(self, name)

--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -153,6 +153,10 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     or localhost) will be checked against this value. If they do not match,
     an error will be raised.
 
+    If the defined or detected runtime ever changes so that it no longer
+    matches the deployment package in S3, the deployment package in S3 will be
+    deleted and a new one will be built and uploaded.
+
     """
 
     source_code: DirectoryPath

--- a/tests/unit/cfngin/hooks/awslambda/test_mixins.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_mixins.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pytest
 from mock import Mock
+from runway.compat import cached_property
 
-from awslambda.mixins import CliInterfaceMixin
+from awslambda.mixins import CliInterfaceMixin, DelCachedPropMixin
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -164,3 +165,34 @@ class TestCliInterfaceMixin:
         assert CliInterface.list2cmdline("foo") == mock_list2cmdline.return_value
         mock_list2cmdline.assert_called_once_with("foo")
         mock_join.assert_not_called()
+
+
+class TestDelCachedPropMixin:
+    """Test DelCachedPropMixin."""
+
+    class Kls(DelCachedPropMixin):
+        """Used in tests."""
+
+        counter = 0
+
+        @cached_property
+        def test_prop(self) -> str:
+            """Test property."""
+            self.counter += 1
+            return "foobar"
+
+    def test__del_cached_property(self) -> None:
+        """Test _del_cached_property."""
+        obj = self.Kls()
+        # ensure suppression is working as expected
+        assert obj.counter == 0
+        assert not obj._del_cached_property("test_prop")
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 1
+        # ensure value is cached and not being evaluated each call
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 1
+        # this would fail if the suppresion was outside the loop
+        assert not obj._del_cached_property("invalid", "test_prop")
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 2

--- a/tests/unit/cfngin/hooks/awslambda/test_python.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_python.py
@@ -58,7 +58,7 @@ class TestPythonFunction:
         deployment_package = mocker.patch.object(PythonFunction, "deployment_package")
         project = mocker.patch.object(PythonFunction, "project")
         assert not PythonFunction(Mock(), **args.dict()).cleanup_on_error()
-        deployment_package.archive_file.unlink.assert_called_once_with(missing_ok=True)
+        deployment_package.delete.assert_called_once_with()
         project.cleanup_on_error.assert_called_once_with()
 
     def test_deployment_package(


### PR DESCRIPTION
# Summary

When a runtime change is detected (local definition does not match S3 object tag) the deployment package is deleted and rebuilt.

# Why This Is Needed

resolves #86 

# What Changed

## Added

- added `awslambda.deployment_package.DeploymentPackage.delete()`
- added `awslambda.deployment_package.DeploymentPackageS3Object.delete()`
- added `awslambda.exceptions.S3ObjectDoesNotExistError`
- added `awslambda.mixins.DelCachedPropMixin`

## Changed

- classes that need to clear the value of a `functools.cached_property` now use the `awslambda.mixins.DelCachedPropMixin` mixin
- `awslambda.deployment_package.DeploymentPackageS3Object.build()` now checks to ensure the object exists before returning instead of assuming it exists
- `awslambda.deployment_package.DeploymentPackageS3Object.upload()` now checks to ensure the object exists before returning instead of assuming it exists
- added `runtime` to local deployment package archive file name
	- allows for tracking of `runtime` changes on local artifact
