### PR TITLE
add support for lambda layers

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -87,6 +87,7 @@
         "pyrightconfig",
         "rcfile",
         "rglob",
+        "runtimes",
         "SSEKMS",
         "stubber",
         "stubbers",

--- a/awslambda/__init__.py
+++ b/awslambda/__init__.py
@@ -1,7 +1,7 @@
 """AWS Lambda hooks."""
 import sys
 
-from ._python import PythonFunction
+from ._python import PythonFunction, PythonLayer
 
 if sys.version_info < (3, 8):  # cov: ignore
     # importlib.metadata is standard lib for python>=3.8, use backport
@@ -15,7 +15,7 @@ else:
         version,
     )
 
-__all__ = ["__version__", "PythonFunction"]
+__all__ = ["__version__", "PythonFunction", "PythonLayer"]
 
 try:  # cov: ignore
     __version__ = version(__name__)

--- a/awslambda/_python.py
+++ b/awslambda/_python.py
@@ -35,7 +35,9 @@ class PythonFunction(AwsLambdaHook[PythonProject]):
     @cached_property
     def deployment_package(self) -> DeploymentPackage[PythonProject]:
         """AWS Lambda deployment package."""
-        return PythonDeploymentPackage.init(self.project)
+        return PythonDeploymentPackage.init(
+            self.project, "layer" if self.BUILD_LAYER else "function"
+        )
 
     @cached_property
     def project(self) -> PythonProject:
@@ -54,7 +56,7 @@ class PythonFunction(AwsLambdaHook[PythonProject]):
     def pre_deploy(self) -> Any:
         """Run during the **pre_deploy** stage."""
         try:
-            self.deployment_package.upload(layer=self.BUILD_LAYER)
+            self.deployment_package.upload()
             return self.build_response("deploy").dict(by_alias=True)
         except BaseException:
             self.cleanup_on_error()

--- a/awslambda/_python.py
+++ b/awslambda/_python.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from runway.compat import cached_property
 
 from .base_classes import AwsLambdaHook
-from .models.args import PythonFunctionHookArgs
+from .models.args import PythonHookArgs
 from .python_requirements import PythonDeploymentPackage, PythonProject
 
 if TYPE_CHECKING:
@@ -24,13 +24,13 @@ class PythonFunction(AwsLambdaHook[PythonProject]):
     BUILD_LAYER: ClassVar[bool] = False
     """Flag to denote that this hook creates a Lambda Function deployment package."""
 
-    args: PythonFunctionHookArgs
+    args: PythonHookArgs
     """Parsed hook arguments."""
 
     def __init__(self, context: CfnginContext, **kwargs: Any) -> None:
         """Instantiate class."""
         super().__init__(context)
-        self.args = PythonFunctionHookArgs.parse_obj(kwargs)
+        self.args = PythonHookArgs.parse_obj(kwargs)
 
     @cached_property
     def deployment_package(self) -> DeploymentPackage[PythonProject]:

--- a/awslambda/base_classes.py
+++ b/awslambda/base_classes.py
@@ -410,6 +410,9 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
         return AwsLambdaHookDeployResponse(
             bucket_name=self.deployment_package.bucket.name,
             code_sha256=self.deployment_package.code_sha256,
+            compatible_architectures=self.deployment_package.compatible_architectures,
+            compatible_runtimes=self.deployment_package.compatible_runtimes,
+            license=self.deployment_package.license,
             object_key=self.deployment_package.object_key,
             object_version_id=self.deployment_package.object_version_id,
             runtime=self.deployment_package.runtime,
@@ -425,6 +428,9 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
             return AwsLambdaHookDeployResponse(
                 bucket_name=self.deployment_package.bucket.name,
                 code_sha256=self.deployment_package.code_sha256,
+                compatible_architectures=self.deployment_package.compatible_architectures,
+                compatible_runtimes=self.deployment_package.compatible_runtimes,
+                license=self.deployment_package.license,
                 object_key=self.deployment_package.object_key,
                 object_version_id=self.deployment_package.object_version_id,
                 runtime=self.deployment_package.runtime,
@@ -433,6 +439,9 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
             return AwsLambdaHookDeployResponse(
                 bucket_name=self.deployment_package.bucket.name,
                 code_sha256="WILL CALCULATE WHEN BUILT",
+                compatible_architectures=self.deployment_package.compatible_architectures,
+                compatible_runtimes=self.deployment_package.compatible_runtimes,
+                license=self.deployment_package.license,
                 object_key=self.deployment_package.object_key,
                 object_version_id=self.deployment_package.object_version_id,
                 runtime=self.deployment_package.runtime,

--- a/awslambda/deployment_package.py
+++ b/awslambda/deployment_package.py
@@ -345,12 +345,12 @@ class DeploymentPackage(DelCachedPropMixin, Generic[_ProjectTypeVar]):
 
         """
         optional_metadata = {
-            self.META_TAGS["compatible_architectures"]: ", ".join(
+            self.META_TAGS["compatible_architectures"]: "+".join(
                 self.project.compatible_architectures
             )
             if self.project.compatible_architectures
             else None,
-            self.META_TAGS["compatible_runtimes"]: ", ".join(
+            self.META_TAGS["compatible_runtimes"]: "+".join(
                 self.project.compatible_runtimes
             )
             if self.project.compatible_runtimes
@@ -511,7 +511,7 @@ class DeploymentPackageS3Object(DeploymentPackage[_ProjectTypeVar]):
         """List of compatible instruction set architectures."""
         if self.META_TAGS["compatible_architectures"] in self.object_tags:
             return self.object_tags[self.META_TAGS["compatible_architectures"]].split(
-                ", "
+                "+"
             )
         return None
 
@@ -519,7 +519,7 @@ class DeploymentPackageS3Object(DeploymentPackage[_ProjectTypeVar]):
     def compatible_runtimes(self) -> Optional[List[str]]:
         """List of compatible runtimes."""
         if self.META_TAGS["compatible_runtimes"] in self.object_tags:
-            return self.object_tags[self.META_TAGS["compatible_runtimes"]].split(", ")
+            return self.object_tags[self.META_TAGS["compatible_runtimes"]].split("+")
         return None
 
     @cached_property

--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -222,8 +222,8 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
         return v
 
 
-class PythonFunctionHookArgs(AwsLambdaHookArgs):
-    """Hook arguments for a Python function."""
+class PythonHookArgs(AwsLambdaHookArgs):
+    """Hook arguments for a Python AWS Lambda deployment package."""
 
     extend_pip_args: Optional[List[str]] = None
     """Additional arguments that should be passed to ``pip install``.

--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -106,17 +106,29 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
 
     bucket_name: str
     """Name of the S3 Bucket where deployment package is/will  be stored.
-    The Bucket must be in the same region the Lambda Function is being deployed in."""
+    The Bucket must be in the same region the Lambda Function is being deployed in.
+
+    """
 
     cache_dir: Optional[Path] = None
     """Explicitly define the directory location.
-    Must be an absolute path or it will be relative to the CFNgin module directory."""
+    Must be an absolute path or it will be relative to the CFNgin module directory.
+
+    """
 
     compatible_architectures: Optional[List[str]] = None
     """A list of compatible instruction set architectures.
     (https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html)
 
-    **Only used for Lambda Layers.**
+    Only used by Lambda Layers.
+
+    .. rubric:: Example
+    .. code-block:: yaml
+
+        args:
+          compatible_architectures:
+            - x86_64
+            - arm64
 
     """
 
@@ -124,7 +136,15 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     """A list of compatible function runtimes.
     Used for filtering with ``ListLayers`` and ``ListLayerVersions``.
 
-    **Only used for Lambda Layers.**
+    Only used by Lambda Layers.
+
+    .. rubric:: Example
+    .. code-block:: yaml
+
+        args:
+          compatible_runtimes:
+            - python3.8
+            - python3.9
 
     """
 
@@ -152,12 +172,18 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     license: Optional[str] = None
     """The layer's software license. Can be any of the following:
 
-    - A SPDX license identifier (e.g. ``MIT``).
+    - A SPDX license identifier (e.g. ``Apache-2.0``).
     - The URL of a license hosted on the internet (e.g.
-      ``https://opensource.org/licenses/MIT``).
+      ``https://opensource.org/licenses/Apache-2.0``).
     - The full text of the license.
 
-    **Only used for Lambda Layers.**
+    Only used by Lambda Layers.
+
+    .. rubric:: Example
+    .. code-block:: yaml
+
+        args:
+          license: Apache-2.0
 
     """
 
@@ -166,7 +192,7 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
 
     The object will always be prefixed with ``awslambda/functions``.
     If provided, the value will be added to the end of the static prefix
-    (e.g. ``awslambda/functions/<object_prefix>/<file-name>``).
+    (e.g. ``awslambda/<functions|layers>/<object_prefix>/<file name>``).
 
     """
 
@@ -188,7 +214,15 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     """
 
     source_code: DirectoryPath
-    """Path to the Lambda Function source code."""
+    """Path to the Lambda Function source code.
+
+    .. rubric:: Example
+    .. code-block:: yaml
+
+        args:
+          source_code: ./my/package
+
+    """
 
     use_cache: bool = True
     """Whether to use a cache directory with pip that will persist builds (default ``True``)."""

--- a/awslambda/models/responses.py
+++ b/awslambda/models/responses.py
@@ -1,5 +1,5 @@
 """Response data models."""
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import Extra, Field
 from runway.utils import BaseModel
@@ -22,7 +22,35 @@ class AwsLambdaHookDeployResponse(BaseModel):
     code_sha256: str = Field(..., alias="CodeSha256")
     """SHA256 of the deployment package.
     This can be used by CloudFormation as the value of ``AWS::Lambda::Version.CodeSha256``.
-    (alias ``CodeSha256``)"""
+    (alias ``CodeSha256``)
+
+    """
+
+    compatible_architectures: Optional[List[str]] = Field(
+        None, alias="CompatibleArchitectures"
+    )
+    """A list of compatible instruction set architectures.
+    (https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html)
+    (alias ``CompatibleArchitectures``)
+
+    """
+
+    compatible_runtimes: Optional[List[str]] = Field(None, alias="CompatibleRuntimes")
+    """A list of compatible function runtimes.
+    Used for filtering with ``ListLayers`` and ``ListLayerVersions``.
+    (alias ``CompatibleRuntimes``)
+
+    """
+
+    license: Optional[str] = Field(None, alias="License")
+    """The layer's software license (alias ``License``). Can be any of the following:
+
+    - A SPDX license identifier (e.g. ``MIT``).
+    - The URL of a license hosted on the internet (e.g.
+      ``https://opensource.org/licenses/MIT``).
+    - The full text of the license.
+
+    """
 
     object_key: str = Field(..., alias="S3Key")
     """Key (file path) of the deployment package S3 Object. (alias ``S3Key``)"""
@@ -30,7 +58,9 @@ class AwsLambdaHookDeployResponse(BaseModel):
     object_version_id: Optional[str] = Field(None, alias="S3ObjectVersion")
     """The version ID of the deployment package S3 Object.
     This will only have a value if the S3 Bucket has versioning enabled.
-    (alias ``S3ObjectVersion``)"""
+    (alias ``S3ObjectVersion``)
+
+    """
 
     runtime: str = Field(..., alias="Runtime")
     """Runtime of the Lambda Function. (alias ``Runtime``)"""

--- a/awslambda/python_requirements/_deployment_package.py
+++ b/awslambda/python_requirements/_deployment_package.py
@@ -1,6 +1,7 @@
 """AWS Lambda Python Deployment Package."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 from igittigitt import IgnoreParser
@@ -29,3 +30,15 @@ class PythonDeploymentPackage(DeploymentPackage[PythonProject]):
         gitignore_filter.add_rule("**/*.dist-info*", self.project.dependency_directory)
         gitignore_filter.add_rule("**/*.py[c|o]", self.project.dependency_directory)
         return gitignore_filter
+
+    @staticmethod
+    def insert_layer_dir(file_path: Path, relative_to: Path) -> Path:
+        """Insert ``python`` directory into local file path for layer archive.
+
+        Args:
+            file_path: Path to local file.
+            relative_to: Path to a directory that the file_path will be relative
+                to in the deployment package.
+
+        """
+        return relative_to / f"python/{file_path.relative_to(relative_to)}"

--- a/awslambda/python_requirements/_python_project.py
+++ b/awslambda/python_requirements/_python_project.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 
 from ..base_classes import Project
 from ..constants import BASE_WORK_DIR
-from ..models.args import PythonFunctionHookArgs
+from ..models.args import PythonHookArgs
 from ._python_docker import PythonDockerDependencyInstaller
 from .dependency_managers import (
     Pip,
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(f"runway.{__name__}")
 
 
-class PythonProject(Project[PythonFunctionHookArgs]):
+class PythonProject(Project[PythonHookArgs]):
     """Python project."""
 
     DEFAULT_CACHE_DIR_NAME: ClassVar[str] = "pip_cache"

--- a/awslambda_lookup/__init__.py
+++ b/awslambda_lookup/__init__.py
@@ -37,13 +37,25 @@ else:
 __all__ = ["__version__", "AwsLambdaLookup"]
 
 # quick way to register everything with one line in the CFNgin config file
-register_lookup_handler(AwsLambdaLookup.Code.NAME, AwsLambdaLookup.Code)
-register_lookup_handler(AwsLambdaLookup.CodeSha256.NAME, AwsLambdaLookup.CodeSha256)
-register_lookup_handler(AwsLambdaLookup.Runtime.NAME, AwsLambdaLookup.Runtime)
-register_lookup_handler(AwsLambdaLookup.S3Bucket.NAME, AwsLambdaLookup.S3Bucket)
-register_lookup_handler(AwsLambdaLookup.S3Key.NAME, AwsLambdaLookup.S3Key)
+register_lookup_handler(AwsLambdaLookup.Code.TYPE_NAME, AwsLambdaLookup.Code)
 register_lookup_handler(
-    AwsLambdaLookup.S3ObjectVersion.NAME, AwsLambdaLookup.S3ObjectVersion
+    AwsLambdaLookup.CodeSha256.TYPE_NAME, AwsLambdaLookup.CodeSha256
+)
+register_lookup_handler(
+    AwsLambdaLookup.CompatibleArchitectures.TYPE_NAME,
+    AwsLambdaLookup.CompatibleArchitectures,
+)
+register_lookup_handler(
+    AwsLambdaLookup.CompatibleRuntimes.TYPE_NAME, AwsLambdaLookup.CompatibleRuntimes
+)
+register_lookup_handler(
+    AwsLambdaLookup.LicenseInfo.TYPE_NAME, AwsLambdaLookup.LicenseInfo
+)
+register_lookup_handler(AwsLambdaLookup.Runtime.TYPE_NAME, AwsLambdaLookup.Runtime)
+register_lookup_handler(AwsLambdaLookup.S3Bucket.TYPE_NAME, AwsLambdaLookup.S3Bucket)
+register_lookup_handler(AwsLambdaLookup.S3Key.TYPE_NAME, AwsLambdaLookup.S3Key)
+register_lookup_handler(
+    AwsLambdaLookup.S3ObjectVersion.TYPE_NAME, AwsLambdaLookup.S3ObjectVersion
 )
 
 try:  # cov: ignore

--- a/docs/source/hooks/python/function.rst
+++ b/docs/source/hooks/python/function.rst
@@ -30,15 +30,15 @@ Arguments that can be passed to hook in the :attr:`~cfngin.hook.args` field.
 Documentation for each field is automatically generated from class attributes in the source code.
 When specifying the field, exclude the class name.
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.bucket_name
+.. autoattribute:: awslambda.models.args.PythonHookArgs.bucket_name
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.cache_dir
+.. autoattribute:: awslambda.models.args.PythonHookArgs.cache_dir
   :noindex:
 
   If not provided, the cache directory is ``.runway/awslambda/pip_cache`` within the current working directory.
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.docker
+.. autoattribute:: awslambda.models.args.PythonHookArgs.docker
   :noindex:
 
   .. autoattribute:: awslambda.models.args.DockerOptions.disabled
@@ -56,28 +56,28 @@ When specifying the field, exclude the class name.
   .. autoattribute:: awslambda.models.args.DockerOptions.pull
     :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.extend_gitignore
+.. autoattribute:: awslambda.models.args.PythonHookArgs.extend_gitignore
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.extend_pip_args
+.. autoattribute:: awslambda.models.args.PythonHookArgs.extend_pip_args
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.object_prefix
+.. autoattribute:: awslambda.models.args.PythonHookArgs.object_prefix
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.runtime
+.. autoattribute:: awslambda.models.args.PythonHookArgs.runtime
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.source_code
+.. autoattribute:: awslambda.models.args.PythonHookArgs.source_code
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.use_cache
+.. autoattribute:: awslambda.models.args.PythonHookArgs.use_cache
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.use_pipenv
+.. autoattribute:: awslambda.models.args.PythonHookArgs.use_pipenv
   :noindex:
 
-.. autoattribute:: awslambda.models.args.PythonFunctionHookArgs.use_poetry
+.. autoattribute:: awslambda.models.args.PythonHookArgs.use_poetry
   :noindex:
 
 

--- a/docs/source/hooks/python/layer.rst
+++ b/docs/source/hooks/python/layer.rst
@@ -1,8 +1,8 @@
-##############
-PythonFunction
-##############
+###########
+PythonLayer
+###########
 
-This hook creates deployment packages for Python Lambda Functions, uploads them to S3, and returns data about the deployment package.
+This hook creates deployment packages for Python Lambda Layers, uploads them to S3, and returns data about the deployment package.
 
 The return value can be retrieved using the :ref:`hook_data Lookup <hook_data lookup>` or by interacting with the :class:`~runway.context.CfnginContext` object passed to the |Blueprint|.
 
@@ -18,7 +18,6 @@ It also ensures that binary files built during the install process are compatibl
 
 .. contents:: Table of Contents
   :local:
-
 
 
 ****
@@ -37,6 +36,12 @@ When specifying the field, exclude the class name.
   :noindex:
 
   If not provided, the cache directory is ``.runway/awslambda/pip_cache`` within the current working directory.
+
+.. autoattribute:: awslambda.models.args.PythonHookArgs.compatible_architectures
+  :noindex:
+
+.. autoattribute:: awslambda.models.args.PythonHookArgs.compatible_runtimes
+  :noindex:
 
 .. autoattribute:: awslambda.models.args.PythonHookArgs.docker
   :noindex:
@@ -60,6 +65,9 @@ When specifying the field, exclude the class name.
   :noindex:
 
 .. autoattribute:: awslambda.models.args.PythonHookArgs.extend_pip_args
+  :noindex:
+
+.. autoattribute:: awslambda.models.args.PythonHookArgs.license
   :noindex:
 
 .. autoattribute:: awslambda.models.args.PythonHookArgs.object_prefix
@@ -115,10 +123,13 @@ Example
   src_path: ./
 
   pre_deploy:
-    - path: awslambda.PythonFunction
+    - path: awslambda.PythonLayer
       data_key: awslambda.example-function-no-docker
       args:
         bucket_name: ${bucket_name}
+        compatible_runtimes:
+          - python3.8
+          - python3.9
         docker:
           disabled: true
         extend_gitignore:
@@ -129,9 +140,9 @@ Example
         extend_pip_args:
           - '--proxy'
           - '[user:passwd@]proxy.server:port'
-        runtime: python3.9
+        runtime: python3.8
         source_code: ./src/example-function
-    - path: awslambda.PythonFunction
+    - path: awslambda.PythonLayer
       data_key: awslambda.example-function
       args:
         bucket_name: ${bucket_name}
@@ -149,7 +160,7 @@ Example
           - '[user:passwd@]proxy.server:port'
         runtime: python3.9
         source_code: ./src/example-function
-    - path: awslambda.PythonFunction
+    - path: awslambda.PythonLayer
       data_key: awslambda.xmlsec
       args:
         bucket_name: ${bucket_name}
@@ -169,8 +180,7 @@ Example
     - name: example-stack
       class_path: blueprints.ExampleBlueprint
       parameters:
-        XmlCodeSha256: ${awslambda.CodeSha256 awslambda.xmlsec}
-        XmlRuntime: ${awslambda.Runtime awslambda.xmlsec}
+        XmlCompatibleRuntimes: ${awslambda.CompatibleRuntimes awslambda.xmlsec}
         XmlS3Bucket: ${awslambda.S3Bucket awslambda.xmlsec}
         XmlS3Key: ${awslambda.S3Key awslambda.xmlsec}
     ...

--- a/docs/source/lookups/awslambda.CompatibleArchitectures.rst
+++ b/docs/source/lookups/awslambda.CompatibleArchitectures.rst
@@ -1,0 +1,50 @@
+.. _AWS::Lambda::LayerVersion.CompatibleArchitectures: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html#cfn-lambda-layerversion-compatiblearchitectures
+
+#################################
+awslambda.CompatibleArchitectures
+#################################
+
+.. automodule:: awslambda_lookup._lookup
+  :exclude-members: AwsLambdaLookup
+  :noindex:
+
+A list of strings or ``None`` is returned by this lookup.
+The returned value can be passed directly to `AWS::Lambda::LayerVersion.CompatibleArchitectures`_.
+
+
+.. rubric:: Arguments
+
+This lookup only supports the ``transform`` argument which can be used to turn the list of strings into a comma delimited list.
+
+
+.. rubric:: Example
+.. code-block:: yaml
+
+  namespace: example
+  cfngin_bucket: ''
+  sys_path: ./
+
+  lookups:
+    awslambda: awslambda_lookup.AwsLambdaLookup
+
+  pre_deploy:
+    - path: awslambda.PythonLayer
+      data_key: example-layer-01
+      args:
+        ...
+    - path: awslambda.PythonLayer
+      data_key: example-layer-02
+      args:
+        ...
+
+  stacks:
+    - name: example-stack-01
+      class_path: blueprints.FooStack
+      variables:
+        CompatibleArchitectures: ${awslambda.CompatibleArchitectures example-layer-01}
+        ...
+    - name: example-stack-02
+      template_path: ./templates/bar-stack.yml
+      variables:
+        CompatibleArchitectures: ${awslambda.CompatibleArchitectures example-layer-02::transform=str}
+        ...

--- a/docs/source/lookups/awslambda.CompatibleRuntimes.rst
+++ b/docs/source/lookups/awslambda.CompatibleRuntimes.rst
@@ -1,0 +1,50 @@
+.. _AWS::Lambda::LayerVersion.CompatibleRuntimes: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html#cfn-lambda-layerversion-compatibleruntimes
+
+############################
+awslambda.CompatibleRuntimes
+############################
+
+.. automodule:: awslambda_lookup._lookup
+  :exclude-members: AwsLambdaLookup
+  :noindex:
+
+A list of strings or ``None`` is returned by this lookup.
+The returned value can be passed directly to `AWS::Lambda::LayerVersion.CompatibleRuntimes`_.
+
+
+.. rubric:: Arguments
+
+This lookup only supports the ``transform`` argument which can be used to turn the list of strings into a comma delimited list.
+
+
+.. rubric:: Example
+.. code-block:: yaml
+
+  namespace: example
+  cfngin_bucket: ''
+  sys_path: ./
+
+  lookups:
+    awslambda: awslambda_lookup.AwsLambdaLookup
+
+  pre_deploy:
+    - path: awslambda.PythonLayer
+      data_key: example-layer-01
+      args:
+        ...
+    - path: awslambda.PythonLayer
+      data_key: example-layer-02
+      args:
+        ...
+
+  stacks:
+    - name: example-stack-01
+      class_path: blueprints.FooStack
+      variables:
+        CompatibleRuntimes: ${awslambda.CompatibleRuntimes example-layer-01}
+        ...
+    - name: example-stack-02
+      template_path: ./templates/bar-stack.yml
+      variables:
+        CompatibleRuntimes: ${awslambda.CompatibleRuntimes example-layer-02::transform=str}
+        ...

--- a/docs/source/lookups/awslambda.License.rst
+++ b/docs/source/lookups/awslambda.License.rst
@@ -1,0 +1,45 @@
+.. _AWS::Lambda::LayerVersion.License: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html#cfn-lambda-layerversion-license
+
+#################
+awslambda.License
+#################
+
+.. automodule:: awslambda_lookup._lookup
+  :exclude-members: AwsLambdaLookup
+  :noindex:
+
+A string or ``None`` is returned by this lookup.
+The returned value can be passed directly to `AWS::Lambda::LayerVersion.License`_.
+
+
+.. rubric:: Example
+.. code-block:: yaml
+
+  namespace: example
+  cfngin_bucket: ''
+  sys_path: ./
+
+  lookups:
+    awslambda: awslambda_lookup.AwsLambdaLookup
+
+  pre_deploy:
+    - path: awslambda.PythonLayer
+      data_key: example-layer-01
+      args:
+        ...
+    - path: awslambda.PythonLayer
+      data_key: example-layer-02
+      args:
+        ...
+
+  stacks:
+    - name: example-stack-01
+      class_path: blueprints.FooStack
+      variables:
+        License: ${awslambda.License example-layer-01}
+        ...
+    - name: example-stack-02
+      template_path: ./templates/bar-stack.yml
+      variables:
+        License: ${awslambda.License example-layer-02}
+        ...

--- a/docs/source/lookups/awslambda.S3Bucket.rst
+++ b/docs/source/lookups/awslambda.S3Bucket.rst
@@ -1,4 +1,5 @@
 .. _AWS::Lambda::Function.Code.S3Bucket: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-s3bucket
+.. _AWS::Lambda::LayerVersion.Content.S3Bucket: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-layerversion-content.html#cfn-lambda-layerversion-content-s3bucket
 
 ##################
 awslambda.S3Bucket
@@ -9,7 +10,7 @@ awslambda.S3Bucket
   :noindex:
 
 A string is returned by this lookup.
-The returned value can be passed directly to `AWS::Lambda::Function.Code.S3Bucket`_.
+The returned value can be passed directly to `AWS::Lambda::Function.Code.S3Bucket`_ or `AWS::Lambda::LayerVersion.Content.S3Bucket`_.
 
 
 .. rubric:: Example

--- a/docs/source/lookups/awslambda.S3Key.rst
+++ b/docs/source/lookups/awslambda.S3Key.rst
@@ -1,4 +1,5 @@
 .. _AWS::Lambda::Function.Code.S3Key: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-s3key
+.. _AWS::Lambda::LayerVersion.Content.S3Key: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-layerversion-content.html#cfn-lambda-layerversion-content-s3key
 
 ###############
 awslambda.S3Key
@@ -9,7 +10,7 @@ awslambda.S3Key
   :noindex:
 
 A string is returned by this lookup.
-The returned value can be passed directly to `AWS::Lambda::Function.Code.S3Key`_.
+The returned value can be passed directly to `AWS::Lambda::Function.Code.S3Key`_ or `AWS::Lambda::LayerVersion.Content.S3Key`_.
 
 
 .. rubric:: Example

--- a/docs/source/lookups/awslambda.S3ObjectVersion.rst
+++ b/docs/source/lookups/awslambda.S3ObjectVersion.rst
@@ -1,4 +1,5 @@
 .. _AWS::Lambda::Function.Code.S3ObjectVersion: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-s3objectversion
+.. _AWS::Lambda::LayerVersion.Content.S3ObjectVersion: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-layerversion-content.html#cfn-lambda-layerversion-content-s3objectversion
 
 #########################
 awslambda.S3ObjectVersion
@@ -9,7 +10,7 @@ awslambda.S3ObjectVersion
   :noindex:
 
 A string is returned by this lookup.
-The returned value can be passed directly to `AWS::Lambda::Function.Code.S3ObjectVersion`_.
+The returned value can be passed directly to `AWS::Lambda::Function.Code.S3ObjectVersion`_ or `AWS::Lambda::LayerVersion.Content.S3ObjectVersion`_.
 
 
 .. rubric:: Example

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -8,11 +8,7 @@ from typing import Any, Dict, Optional
 import pytest
 from pydantic import ValidationError
 
-from awslambda.models.args import (
-    AwsLambdaHookArgs,
-    DockerOptions,
-    PythonFunctionHookArgs,
-)
+from awslambda.models.args import AwsLambdaHookArgs, DockerOptions, PythonHookArgs
 
 MODULE = "awslambda.models.args"
 
@@ -152,12 +148,12 @@ class TestAwsLambdaHookArgs:
         )
 
 
-class TestPythonFunctionHookArgs:
-    """Test PythonFunctionHookArgs."""
+class TestPythonHookArgs:
+    """Test PythonHookArgs."""
 
     def test_extra(self, tmp_path: Path) -> None:
         """Test extra fields."""
-        obj = PythonFunctionHookArgs(
+        obj = PythonHookArgs(
             bucket_name="test-bucket",
             invalid=True,  # type: ignore
             runtime="test",
@@ -167,7 +163,7 @@ class TestPythonFunctionHookArgs:
 
     def test_field_defaults(self, tmp_path: Path) -> None:
         """Test field defaults."""
-        obj = PythonFunctionHookArgs(  # these are all required fields
+        obj = PythonHookArgs(  # these are all required fields
             bucket_name="test-bucket",
             runtime="test",
             source_code=tmp_path,

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from pydantic import ValidationError
@@ -19,6 +19,27 @@ MODULE = "awslambda.models.args"
 
 class TestAwsLambdaHookArgs:
     """Test AwsLambdaHookArgs."""
+
+    @pytest.mark.parametrize("value", ["foobar", None])
+    def test__check_tag_value_length(self, value: Optional[str]) -> None:
+        """Test _check_tag_value_length."""
+        obj = AwsLambdaHookArgs(
+            bucket_name="test-bucket",
+            license=value,
+            runtime="test",
+            source_code="./",  # type: ignore
+        )
+        assert obj.license == value
+
+    def test__check_tag_value_length_raise_value_error(self) -> None:
+        """Test _check_tag_value_length raise ValueError."""
+        with pytest.raises(ValueError):
+            AwsLambdaHookArgs(
+                bucket_name="test-bucket",
+                license="0" * 256,
+                runtime="test",
+                source_code="./",  # type: ignore
+            )
 
     def test___resolve_path(self) -> None:
         """Test _resolve_path."""

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test_deployment_package.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test_deployment_package.py
@@ -9,6 +9,8 @@ from mock import Mock, call
 from awslambda.python_requirements._deployment_package import PythonDeploymentPackage
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 MODULE = "awslambda.python_requirements._deployment_package"
@@ -32,4 +34,17 @@ class TestPythonDeploymentPackage:
                 call("**/*.dist-info*", project.dependency_directory),
                 call("**/*.py[c|o]", project.dependency_directory),
             ]
+        )
+
+    def test_insert_layer_dir(self, tmp_path: Path) -> None:
+        """Test insert_layer_dir."""
+        assert (
+            PythonDeploymentPackage.insert_layer_dir(tmp_path / "foo.txt", tmp_path)
+            == tmp_path / "python" / "foo.txt"
+        )
+        assert (
+            PythonDeploymentPackage.insert_layer_dir(
+                tmp_path / "bar" / "foo.txt", tmp_path
+            )
+            == tmp_path / "python" / "bar" / "foo.txt"
         )

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.base_classes."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use,protected-access,unused-argument
 from __future__ import annotations
 
 import logging
@@ -9,13 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from mock import Mock
 
-from awslambda.base_classes import (
-    AwsLambdaHook,
-    DependencyManager,
-    FunctionHook,
-    LayerHook,
-    Project,
-)
+from awslambda.base_classes import AwsLambdaHook, DependencyManager, Project
 from awslambda.exceptions import RuntimeMismatchError
 from awslambda.models.args import AwsLambdaHookArgs
 from awslambda.models.responses import AwsLambdaHookDeployResponse
@@ -182,34 +176,6 @@ class TestDependencyManager:
             assert DependencyManager(Mock(), tmp_path).version
 
 
-class TestFunctionHook:
-    """Test FunctionHook."""
-
-    def test_deployment_package(self, cfngin_context: CfnginContext) -> None:
-        """Test deployment_package."""
-        with pytest.raises(NotImplementedError):
-            assert FunctionHook(cfngin_context).deployment_package
-
-    def test_project(self, cfngin_context: CfnginContext) -> None:
-        """Test project."""
-        with pytest.raises(NotImplementedError):
-            assert FunctionHook(cfngin_context).project
-
-
-class TestLayerHook:
-    """Test LayerHook."""
-
-    def test_deployment_package(self, cfngin_context: CfnginContext) -> None:
-        """Test deployment_package."""
-        with pytest.raises(NotImplementedError):
-            assert LayerHook(cfngin_context).deployment_package
-
-    def test_project(self, cfngin_context: CfnginContext) -> None:
-        """Test project."""
-        with pytest.raises(NotImplementedError):
-            assert LayerHook(cfngin_context).project
-
-
 class TestProject:
     """Test Project."""
 
@@ -272,6 +238,41 @@ class TestProject:
         """Test cleanup. Should do nothing."""
         assert not Project(Mock(), Mock()).cleanup()
 
+    def test_compatible_architectures(self, tmp_path: Path) -> None:
+        """Test compatible_architectures."""
+        assert not Project(
+            AwsLambdaHookArgs(bucket_name="", runtime="test", source_code=tmp_path),
+            Mock(),
+        ).compatible_architectures
+        assert Project(
+            Mock(compatible_architectures=["foobar"]), Mock
+        ).compatible_architectures == ["foobar"]
+
+    def test_compatible_runtimes(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test compatible_runtimes."""
+        mocker.patch.object(Project, "runtime", "foobar")
+        assert not Project(
+            AwsLambdaHookArgs(bucket_name="", runtime="test", source_code=tmp_path),
+            Mock(),
+        ).compatible_runtimes
+        assert Project(
+            Mock(compatible_runtimes=["foobar"]), Mock()
+        ).compatible_runtimes == ["foobar"]
+
+    def test_compatible_runtimes_raise_value_error(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test compatible_runtimes raise ValueError."""
+        mocker.patch.object(Project, "runtime", "foobar")
+        with pytest.raises(ValueError) as excinfo:
+            assert Project(
+                Mock(compatible_runtimes=["foo", "bar"]), Mock()
+            ).compatible_runtimes
+        assert (
+            str(excinfo.value)
+            == "runtime (foobar) not in compatible runtimes (foo, bar)"
+        )
+
     def test_dependency_directory(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test dependency_directory."""
         mocker.patch.object(Project, "build_directory", tmp_path)
@@ -285,6 +286,14 @@ class TestProject:
         """Test install_dependencies."""
         with pytest.raises(NotImplementedError):
             assert Project(Mock(), Mock()).install_dependencies()
+
+    def test_license(self, tmp_path: Path) -> None:
+        """Test license."""
+        assert not Project(
+            AwsLambdaHookArgs(bucket_name="", runtime="test", source_code=tmp_path),
+            Mock(),
+        ).license
+        assert Project(Mock(license="foobar"), Mock()).license == "foobar"
 
     def test_metadata_files(self) -> None:
         """Test metadata_files."""

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -39,6 +39,9 @@ class TestAwsLambdaHook:
             Mock(
                 bucket=Mock(),
                 code_sha256="sha256",
+                compatible_architectures=None,
+                compatible_runtimes=None,
+                license="license",
                 object_key="key",
                 object_version_id="version",
                 runtime="runtime",
@@ -50,6 +53,7 @@ class TestAwsLambdaHook:
         ) == AwsLambdaHookDeployResponse(
             bucket_name=deployment_package.bucket.name,
             code_sha256=deployment_package.code_sha256,  # type: ignore
+            license="license",
             object_key=deployment_package.object_key,  # type: ignore
             object_version_id=deployment_package.object_version_id,  # type: ignore
             runtime=deployment_package.runtime,  # type: ignore
@@ -67,6 +71,9 @@ class TestAwsLambdaHook:
             Mock(
                 bucket=Mock(),
                 code_sha256="sha256",
+                compatible_architectures=None,
+                compatible_runtimes=None,
+                license=None,
                 object_key="key",
                 object_version_id="version",
                 runtime="runtime",

--- a/tests/unit/cfngin/hooks/awslambda/test_python.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_python.py
@@ -8,7 +8,7 @@ import pytest
 from mock import Mock
 from pydantic import ValidationError
 
-from awslambda._python import PythonFunction
+from awslambda._python import PythonFunction, PythonLayer
 from awslambda.models.args import PythonFunctionHookArgs
 
 if TYPE_CHECKING:
@@ -88,7 +88,7 @@ class TestPythonFunction:
             PythonFunction(Mock(), **args.dict()).pre_deploy()
             == model.dict.return_value
         )
-        deployment_package.upload.assert_called_once_with()
+        deployment_package.upload.assert_called_once_with(layer=False)
         build_response.assert_called_once_with("deploy")
         model.dict.assert_called_once_with(by_alias=True)
         cleanup_on_error.assert_not_called()
@@ -110,7 +110,7 @@ class TestPythonFunction:
         )
         with pytest.raises(Exception):
             assert PythonFunction(Mock(), **args.dict()).pre_deploy()
-        deployment_package.upload.assert_called_once_with()
+        deployment_package.upload.assert_called_once_with(layer=False)
         build_response.assert_not_called()
         cleanup_on_error.assert_called_once_with()
         cleanup.assert_called_once_with()
@@ -121,3 +121,48 @@ class TestPythonFunction:
         project_class = mocker.patch(f"{MODULE}.PythonProject")
         assert PythonFunction(ctx, **args.dict()).project == project_class.return_value
         project_class.assert_called_once_with(args, ctx)
+
+
+class TestPythonLayer:
+    """Test PythonLayer."""
+
+    def test_pre_deploy(
+        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+    ) -> None:
+        """Test pre_deploy."""
+        model = Mock(dict=Mock(return_value="success"))
+        build_response = mocker.patch.object(
+            PythonLayer, "build_response", return_value=(model)
+        )
+        cleanup = mocker.patch.object(PythonLayer, "cleanup")
+        cleanup_on_error = mocker.patch.object(PythonLayer, "cleanup_on_error")
+        deployment_package = mocker.patch.object(PythonLayer, "deployment_package")
+        assert (
+            PythonLayer(Mock(), **args.dict()).pre_deploy() == model.dict.return_value
+        )
+        deployment_package.upload.assert_called_once_with(layer=True)
+        build_response.assert_called_once_with("deploy")
+        model.dict.assert_called_once_with(by_alias=True)
+        cleanup_on_error.assert_not_called()
+        cleanup.assert_called_once_with()
+
+    def test_pre_deploy_always_cleanup(
+        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+    ) -> None:
+        """Test pre_deploy always cleanup."""
+        build_response = mocker.patch.object(
+            PythonLayer, "build_response", return_value="success"
+        )
+        cleanup = mocker.patch.object(PythonLayer, "cleanup")
+        cleanup_on_error = mocker.patch.object(PythonLayer, "cleanup_on_error")
+        deployment_package = mocker.patch.object(
+            PythonLayer,
+            "deployment_package",
+            Mock(upload=Mock(side_effect=Exception)),
+        )
+        with pytest.raises(Exception):
+            assert PythonLayer(Mock(), **args.dict()).pre_deploy()
+        deployment_package.upload.assert_called_once_with(layer=True)
+        build_response.assert_not_called()
+        cleanup_on_error.assert_called_once_with()
+        cleanup.assert_called_once_with()

--- a/tests/unit/cfngin/hooks/awslambda/test_python.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_python.py
@@ -9,7 +9,7 @@ from mock import Mock
 from pydantic import ValidationError
 
 from awslambda._python import PythonFunction, PythonLayer
-from awslambda.models.args import PythonFunctionHookArgs
+from awslambda.models.args import PythonHookArgs
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -20,9 +20,9 @@ MODULE = "awslambda._python"
 
 
 @pytest.fixture(scope="function")
-def args(tmp_path: Path) -> PythonFunctionHookArgs:
+def args(tmp_path: Path) -> PythonHookArgs:
     """Fixture for creating default function args."""
-    return PythonFunctionHookArgs(
+    return PythonHookArgs(
         bucket_name="test-bucket",
         runtime="python3.9",
         source_code=tmp_path,
@@ -32,7 +32,7 @@ def args(tmp_path: Path) -> PythonFunctionHookArgs:
 class TestPythonFunction:
     """Test PythonFunction."""
 
-    def test___init__(self, args: PythonFunctionHookArgs) -> None:
+    def test___init__(self, args: PythonHookArgs) -> None:
         """Test __init__."""
         ctx = Mock()
         obj = PythonFunction(ctx, **args.dict())
@@ -45,14 +45,14 @@ class TestPythonFunction:
         with pytest.raises(ValidationError):
             PythonFunction(Mock(), invalid=True)
 
-    def test_cleanup(self, args: PythonFunctionHookArgs, mocker: MockerFixture) -> None:
+    def test_cleanup(self, args: PythonHookArgs, mocker: MockerFixture) -> None:
         """Test cleanup."""
         project = mocker.patch.object(PythonFunction, "project")
         assert not PythonFunction(Mock(), **args.dict()).cleanup()
         project.cleanup.assert_called_once_with()
 
     def test_cleanup_on_error(
-        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+        self, args: PythonHookArgs, mocker: MockerFixture
     ) -> None:
         """Test cleanup_on_error."""
         deployment_package = mocker.patch.object(PythonFunction, "deployment_package")
@@ -62,7 +62,7 @@ class TestPythonFunction:
         project.cleanup_on_error.assert_called_once_with()
 
     def test_deployment_package(
-        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+        self, args: PythonHookArgs, mocker: MockerFixture
     ) -> None:
         """Test deployment_package."""
         deployment_package_class = mocker.patch(f"{MODULE}.PythonDeploymentPackage")
@@ -73,9 +73,7 @@ class TestPythonFunction:
         )
         deployment_package_class.init.assert_called_once_with(project, "function")
 
-    def test_pre_deploy(
-        self, args: PythonFunctionHookArgs, mocker: MockerFixture
-    ) -> None:
+    def test_pre_deploy(self, args: PythonHookArgs, mocker: MockerFixture) -> None:
         """Test pre_deploy."""
         model = Mock(dict=Mock(return_value="success"))
         build_response = mocker.patch.object(
@@ -95,7 +93,7 @@ class TestPythonFunction:
         cleanup.assert_called_once_with()
 
     def test_pre_deploy_always_cleanup(
-        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+        self, args: PythonHookArgs, mocker: MockerFixture
     ) -> None:
         """Test pre_deploy always cleanup."""
         build_response = mocker.patch.object(
@@ -115,7 +113,7 @@ class TestPythonFunction:
         cleanup_on_error.assert_called_once_with()
         cleanup.assert_called_once_with()
 
-    def test_project(self, args: PythonFunctionHookArgs, mocker: MockerFixture) -> None:
+    def test_project(self, args: PythonHookArgs, mocker: MockerFixture) -> None:
         """Test project."""
         ctx = Mock()
         project_class = mocker.patch(f"{MODULE}.PythonProject")
@@ -127,7 +125,7 @@ class TestPythonLayer:
     """Test PythonLayer."""
 
     def test_deployment_package(
-        self, args: PythonFunctionHookArgs, mocker: MockerFixture
+        self, args: PythonHookArgs, mocker: MockerFixture
     ) -> None:
         """Test deployment_package."""
         deployment_package_class = mocker.patch(f"{MODULE}.PythonDeploymentPackage")


### PR DESCRIPTION
# Summary

Adds support for creating Lambda Layers.

# Why This Is Needed

resolves #80 

# What Changed

## Added

- added `compatible_architectures`, `compatible_runtimes` and `license` args
	- these have also been added as cached properties to the deployment package and project classes
- added `awslambda.PythonLayer`
- added `awslambda.base_classes.AwsLambdaHook.BUILD_LAYER` class variable to denote if the class builds a lambda layer
- added `awslambda.deployment_package.DeploymentPackage.insert_layer_dir()` static method to adjust the directory of files in the archive file so that it can be used as a lambda layer
	- method on parent class has no logic - it must be implemented per language
- added `awslambda.CompatibleArchitectures`, `awslambda.CompatibleRuntimes`, & `awslambda.LicenseInfo` lookups

## Changed

- `awslambda.deployment_package.DeploymentPackage` now takes a `usage_type` argument of either `function` or `layer`
- deployment package S3 object tags will now be updated when there is a change locally
- `awslambda.models.args.PythonFunctionHookArgs` renamed to `awslambda.models.args.PythonHookArgs`

## Removed

- removed `awslambda.base_classes.FunctionHook` class
- removed `awslambda.base_classes.LayerHook` class
