### PR TITLE
add slim & strip options to mimic serverless-python-requirements

### DIFF
--- a/awslambda/models/args.py
+++ b/awslambda/models/args.py
@@ -159,6 +159,8 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
 
     ``.git/`` & ``.gitignore`` will always be added.
 
+    .. important:: This only applies to files in the ``source_code`` directory.
+
     .. rubric:: Example
     .. code-block:: yaml
 
@@ -212,6 +214,13 @@ class AwsLambdaHookArgs(HookArgsBaseModel):
     If the defined or detected runtime ever changes so that it no longer
     matches the deployment package in S3, the deployment package in S3 will be
     deleted and a new one will be built and uploaded.
+
+    """
+
+    slim: bool = True
+    """Automatically remove information and caches from dependencies (default ``True``).
+    This is done by applying gitignore rules to the dependencies.
+    These rules vary by language/runtime.
 
     """
 
@@ -276,6 +285,25 @@ class PythonHookArgs(AwsLambdaHookArgs):
           extend_pip_args:
             - '--proxy'
             - '[user:passwd@]proxy.server:port'
+
+    """
+
+    slim: bool = True
+    """Automatically remove information and caches from dependencies (default ``True``).
+    This is done by applying the following gitignore rules to the dependencies:
+
+    - ``**/*.dist-info*``
+    - ``**/*.py[c|d|i|o]``
+    - ``**/*.so``
+    - ``**/__pycache__*``
+
+    """
+
+    strip: bool = True
+    """Whether or not to strip binary files from the dependencies (default ``True``).
+    This only takes effect if ``slim: true``.
+
+    If false, the gitignore rule ``**/*.so`` is not used.
 
     """
 

--- a/awslambda/python_requirements/_deployment_package.py
+++ b/awslambda/python_requirements/_deployment_package.py
@@ -23,13 +23,21 @@ class PythonDeploymentPackage(DeploymentPackage[PythonProject]):
         This should be overridden by subclasses if a filter should be used.
 
         """
-        gitignore_filter = IgnoreParser()
-
-        # TODO make this configurable
-        gitignore_filter.add_rule("**/__pycache__*", self.project.dependency_directory)
-        gitignore_filter.add_rule("**/*.dist-info*", self.project.dependency_directory)
-        gitignore_filter.add_rule("**/*.py[c|o]", self.project.dependency_directory)
-        return gitignore_filter
+        if self.project.args.slim:
+            gitignore_filter = IgnoreParser()
+            gitignore_filter.add_rule(
+                "**/*.dist-info*", self.project.dependency_directory
+            )
+            gitignore_filter.add_rule(
+                "**/*.py[c|d|i|o]", self.project.dependency_directory
+            )
+            gitignore_filter.add_rule(
+                "**/__pycache__*", self.project.dependency_directory
+            )
+            if self.project.args.strip:
+                gitignore_filter.add_rule("**/*.so", self.project.dependency_directory)
+            return gitignore_filter
+        return None
 
     @staticmethod
     def insert_layer_dir(file_path: Path, relative_to: Path) -> Path:

--- a/docs/source/hooks/python/function.rst
+++ b/docs/source/hooks/python/function.rst
@@ -68,7 +68,13 @@ When specifying the field, exclude the class name.
 .. autoattribute:: awslambda.models.args.PythonHookArgs.runtime
   :noindex:
 
+.. autoattribute:: awslambda.models.args.PythonHookArgs.slim
+  :noindex:
+
 .. autoattribute:: awslambda.models.args.PythonHookArgs.source_code
+  :noindex:
+
+.. autoattribute:: awslambda.models.args.PythonHookArgs.strip
   :noindex:
 
 .. autoattribute:: awslambda.models.args.PythonHookArgs.use_cache
@@ -130,6 +136,7 @@ Example
           - '--proxy'
           - '[user:passwd@]proxy.server:port'
         runtime: python3.9
+        slim: false
         source_code: ./src/example-function
     - path: awslambda.PythonFunction
       data_key: awslambda.example-function
@@ -164,6 +171,7 @@ Example
           - '*.toml'
           - tests/
         source_code: ./src/xmlsec-function
+        strip: false
 
   stacks:
     - name: example-stack

--- a/docs/source/hooks/python/layer.rst
+++ b/docs/source/hooks/python/layer.rst
@@ -76,7 +76,13 @@ When specifying the field, exclude the class name.
 .. autoattribute:: awslambda.models.args.PythonHookArgs.runtime
   :noindex:
 
+.. autoattribute:: awslambda.models.args.PythonHookArgs.slim
+  :noindex:
+
 .. autoattribute:: awslambda.models.args.PythonHookArgs.source_code
+  :noindex:
+
+.. autoattribute:: awslambda.models.args.PythonHookArgs.strip
   :noindex:
 
 .. autoattribute:: awslambda.models.args.PythonHookArgs.use_cache
@@ -141,6 +147,7 @@ Example
           - '--proxy'
           - '[user:passwd@]proxy.server:port'
         runtime: python3.8
+        slim: false
         source_code: ./src/example-function
     - path: awslambda.PythonLayer
       data_key: awslambda.example-function
@@ -175,6 +182,7 @@ Example
           - '*.toml'
           - tests/
         source_code: ./src/xmlsec-function
+        strip: false
 
   stacks:
     - name: example-stack

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test_deployment_package.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test_deployment_package.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from mock import Mock, call
 
 from awslambda.python_requirements._deployment_package import PythonDeploymentPackage
@@ -19,22 +20,35 @@ MODULE = "awslambda.python_requirements._deployment_package"
 class TestPythonDeploymentPackage:
     """Test PythonDeploymentPackage."""
 
-    def test_gitignore_filter(self, mocker: MockerFixture) -> None:
+    @pytest.mark.parametrize(
+        "slim, strip", [(False, False), (False, True), (True, False), (True, True)]
+    )
+    def test_gitignore_filter(
+        self, mocker: MockerFixture, slim: bool, strip: bool
+    ) -> None:
         """Test gitignore_filter."""
         mock_ignore_parser = Mock()
         mock_ignore_parser_class = mocker.patch(
             f"{MODULE}.IgnoreParser", return_value=mock_ignore_parser
         )
         project = Mock(dependency_directory="dependency_directory")
-        assert PythonDeploymentPackage(project).gitignore_filter == mock_ignore_parser
-        mock_ignore_parser_class.assert_called_once_with()
-        mock_ignore_parser.add_rule.assert_has_calls(
-            [
-                call("**/__pycache__*", project.dependency_directory),
+        project.args.slim = slim
+        project.args.strip = strip
+        if slim:
+            assert (
+                PythonDeploymentPackage(project).gitignore_filter == mock_ignore_parser
+            )
+            mock_ignore_parser_class.assert_called_once_with()
+            calls = [
                 call("**/*.dist-info*", project.dependency_directory),
-                call("**/*.py[c|o]", project.dependency_directory),
+                call("**/*.py[c|d|i|o]", project.dependency_directory),
+                call("**/__pycache__*", project.dependency_directory),
             ]
-        )
+            if strip:
+                calls.append(call("**/*.so", project.dependency_directory))
+            mock_ignore_parser.add_rule.assert_has_calls(calls)
+        else:
+            assert not PythonDeploymentPackage(project).gitignore_filter
 
     def test_insert_layer_dir(self, tmp_path: Path) -> None:
         """Test insert_layer_dir."""


### PR DESCRIPTION
# What Changed

## Added

- added `slim` argument to toggle excluding some files from the dependencies
- added `strip` argument to augment the files excluded by `slim` to include/ignore binary files